### PR TITLE
Fixed incorrect enabled flag test for cli in apc checks

### DIFF
--- a/src/Check/ApcFragmentation.php
+++ b/src/Check/ApcFragmentation.php
@@ -87,7 +87,7 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
             return new Skip('APC has not been enabled or installed.');
         }
 
-        if (php_sapi_name() == 'cli' && ! ini_get('apc.enabled_cli')) {
+        if (php_sapi_name() == 'cli' && ! ini_get('apc.enable_cli')) {
             return new Skip('APC has not been enabled in CLI.');
         }
 

--- a/src/Check/ApcMemory.php
+++ b/src/Check/ApcMemory.php
@@ -43,7 +43,7 @@ class ApcMemory extends AbstractMemoryCheck
             return new Skip('APC has not been enabled or installed.');
         }
 
-        if (php_sapi_name() == 'cli' && ! ini_get('apc.enabled_cli')) {
+        if (php_sapi_name() == 'cli' && ! ini_get('apc.enable_cli')) {
             return new Skip('APC has not been enabled in CLI.');
         }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR fixes incorrect  `apc.enable_cli` ini setting test for APC checks.
