### PR TITLE
Fixes references to ZFTool module

### DIFF
--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -6,7 +6,7 @@
 2. Enable diagnostic tests in [your application config.php](https://github.com/zendframework/ZFTool/blob/master/docs/DIAGNOSTICS.md).
 3. In your console type `php public/index.php diag` to run diagnostics.
 
-Note: this does not work with Laminas; use the [plain PHP
+Note: this does not work with Laminas MVC version 3; use the [plain PHP
 diagnostics](#using-diagnostics-in-plain-php) instructions below when using that
 framework version.
 

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -2,8 +2,8 @@
 
 ## Performing diagnostics with Laminas
 
-1. Install the [LaminasTool module](https://github.com/laminas/LaminasTool).
-2. Enable diagnostic tests in [your application config.php](https://github.com/laminas/LaminasTool/blob/master/docs/DIAGNOSTICS.md).
+1. Install the [ZFTool module](https://github.com/zendframework/ZFTool).
+2. Enable diagnostic tests in [your application config.php](https://github.com/zendframework/ZFTool/blob/master/docs/DIAGNOSTICS.md).
 3. In your console type `php public/index.php diag` to run diagnostics.
 
 Note: this does not work with Laminas; use the [plain PHP


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix | yes

### Description

Component zendframework/ZFTool has not been moved to Laminas.

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
