### PR TITLE
PDOCheck.php extends AbstractCheck

### DIFF
--- a/src/Check/PDOCheck.php
+++ b/src/Check/PDOCheck.php
@@ -14,7 +14,7 @@ use PDO;
 /**
  * Ensures a connection to the MySQL server/database is possible.
  */
-class PDOCheck implements CheckInterface
+class PDOCheck extends AbstractCheck
 {
     private $dsn;
     private $password;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

I've noticed that all the checks here extend the AbstractCheck class. As for me, it seems strange that the PDOCheck doesn't.
This small bug doesn't allow to set a custom label for PDOCheck.