### PR TITLE
Replace abandoned Sensiolabs security checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "doctrine/migrations": "^2.0 || ^3.0",
+        "enlightn/security-checker": "^1.2",
         "guzzlehttp/guzzle": "^5.3.3 || ^6.3.3",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-loader": "^2.0",
@@ -40,7 +41,6 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.1",
         "predis/predis": "^1.0",
-        "sensiolabs/security-checker": "^5.0 || ^6.0.3",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "doctrine/migrations": "Required by Check\\DoctrineMigration",
         "guzzlehttp/guzzle": "Required by Check\\GuzzleHttpService",
         "predis/predis": "Required by Check\\Redis",
-        "sensiolabs/security-checker": "Required by Check\\SecurityAdvisory",
+        "enlightn/security-checker": "Required by Check\\SecurityAdvisory",
         "symfony/yaml": "Required by Check\\YamlFile",
         "videlalvaro/php-amqplib": "Required by Check\\RabbitMQ"
     },

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -9,15 +9,15 @@
 namespace LaminasTest\Diagnostics\TestAsset\Check;
 
 use Laminas\Diagnostics\Check\SecurityAdvisory as BaseCheck;
-use SensioLabs\Security\SecurityChecker;
+use Enlightn\SecurityChecker\AdvisoryAnalyzer;
 
 class SecurityAdvisory extends BaseCheck
 {
     /**
-     * @param SecurityChecker $securityChecker
+     * @param \Enlightn\SecurityChecker\AdvisoryAnalyzer $advisoryAnalyzer
      */
-    public function setSecurityChecker(SecurityChecker $securityChecker)
+    public function setAdvisoryAnalyzer(AdvisoryAnalyzer $advisoryAnalyzer)
     {
-        $this->securityChecker = $securityChecker;
+        $this->advisoryAnalyzer = $advisoryAnalyzer;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes/no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR replaces the abandoned [Sensiolabs security checker](https://github.com/sensiolabs/security-checker) with the [Enlightn security checker](https://github.com/enlightn/security-checker).