### PR TITLE
Moved constructor logic into check to avoid unnecessary database connection

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -340,18 +340,24 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/DoctrineMigration.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MixedAssignment occurrences="2">
-      <code>$this-&gt;availableVersions</code>
-      <code>$this-&gt;migratedVersions</code>
-    </MixedAssignment>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>$availableVersions</code>
-      <code>$migratedVersions</code>
+    <DocblockTypeContradiction occurrences="1">
+      <code>! $input instanceof DependencyFactory &amp;&amp; ! $input instanceof Configuration</code>
+    </DocblockTypeContradiction>
+    <MixedInferredReturnType occurrences="2">
+      <code>Version[]</code>
+      <code>Version[]</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$this-&gt;input-&gt;getAvailableVersions()</code>
+      <code>$this-&gt;input-&gt;getMigratedVersions()</code>
+    </MixedReturnStatement>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>DoctrineMigration</code>
     </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="2">
+      <code>getAvailableVersions</code>
+      <code>getMigratedVersions</code>
+    </UndefinedMethod>
   </file>
   <file src="src/Check/ExtensionLoaded.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1175,9 +1181,9 @@
       <code>$expectedResult</code>
       <code>$expectedResult</code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="1">
-      <code>testThrowsExceptionForInvalidInput</code>
-    </MissingReturnType>
+    <InvalidArgument occurrences="1">
+      <code>new \stdClass()</code>
+    </InvalidArgument>
     <MixedArgument occurrences="2">
       <code>$version</code>
       <code>$version</code>

--- a/src/Check/DoctrineMigration.php
+++ b/src/Check/DoctrineMigration.php
@@ -45,8 +45,8 @@ class DoctrineMigration extends AbstractCheck
      */
     public function check(): ResultInterface
     {
-        $availableVersions = $this->getAvailableVersionsFromInput($this->input);
-        $migratedVersions = $this->getMigratedVersionsFromInput($this->input);
+        $availableVersions = $this->getAvailableVersions();
+        $migratedVersions = $this->getMigratedVersions();
 
         $notMigratedVersions = array_diff($availableVersions, $migratedVersions);
         if (! empty($notMigratedVersions)) {
@@ -62,13 +62,12 @@ class DoctrineMigration extends AbstractCheck
     }
 
     /**
-     * @param DependencyFactory|Configuration $input
      * @return Version[]
      */
-    private function getAvailableVersionsFromInput($input): array
+    private function getAvailableVersions(): array
     {
         if ($this->input instanceof DependencyFactory) {
-            return $this->getAvailableVersionsFromDependencyFactory($input);
+            return $this->getAvailableVersionsFromDependencyFactory($this->input);
         }
 
         if ($this->input instanceof Configuration) {
@@ -82,13 +81,12 @@ class DoctrineMigration extends AbstractCheck
     }
 
     /**
-     * @param DependencyFactory|Configuration $input
      * @return Version[]
      */
-    private function getMigratedVersionsFromInput($input): array
+    private function getMigratedVersions(): array
     {
         if ($this->input instanceof DependencyFactory) {
-            return $this->getMigratedVersionsFromDependencyFactory($input);
+            return $this->getMigratedVersionsFromDependencyFactory($this->input);
         }
 
         if ($this->input instanceof Configuration) {

--- a/src/Check/DoctrineMigration.php
+++ b/src/Check/DoctrineMigration.php
@@ -24,6 +24,12 @@ class DoctrineMigration extends AbstractCheck
      */
     private $input;
 
+    /**
+     * @param DependencyFactory|Configuration $input
+     *
+     * @throws InvalidArgumentException if an invalid $input is given - note that this exception will
+     *                                  be removed once PHP 8 union types are introduced here.
+     */
     public function __construct($input)
     {
         if (! $input instanceof DependencyFactory && ! $input instanceof Configuration) {

--- a/src/Check/DoctrineMigration.php
+++ b/src/Check/DoctrineMigration.php
@@ -70,14 +70,7 @@ class DoctrineMigration extends AbstractCheck
             return $this->getAvailableVersionsFromDependencyFactory($this->input);
         }
 
-        if ($this->input instanceof Configuration) {
-            return $this->input->getAvailableVersions();
-        }
-
-        throw new LogicException(<<<'MESSAGE'
-            Unexpected class for $input detected. Could not check for Doctrine Migrations.
-            MESSAGE
-        );
+        return $this->input->getAvailableVersions();
     }
 
     /**
@@ -89,14 +82,7 @@ class DoctrineMigration extends AbstractCheck
             return $this->getMigratedVersionsFromDependencyFactory($this->input);
         }
 
-        if ($this->input instanceof Configuration) {
-            return $this->input->getMigratedVersions();
-        }
-
-        throw new LogicException(<<<'MESSAGE'
-            Unexpected class for $input detected. Could not check for Doctrine Migrations.
-            MESSAGE
-        );
+        return $this->input->getMigratedVersions();
     }
 
     /**

--- a/test/DoctrineMigrationTest.php
+++ b/test/DoctrineMigrationTest.php
@@ -111,7 +111,7 @@ class DoctrineMigrationTest extends TestCase
         self::assertInstanceof($expectedResult, $result);
     }
 
-    public function testThrowsExceptionForInvalidInput()
+    public function testThrowsExceptionForInvalidInput(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid Argument for DoctrineMigration check.');
@@ -119,7 +119,7 @@ class DoctrineMigrationTest extends TestCase
         new DoctrineMigration(new \stdClass());
     }
 
-    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion3()
+    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion3(): void
     {
         if (! $this->isDoctrineVersion3Installed()) {
             self::markTestSkipped('Doctrine Version 3 is not installed, skipping test.');
@@ -142,7 +142,7 @@ class DoctrineMigrationTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion2()
+    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion2(): void
     {
         if (! $this->isDoctrineVersion2Installed()) {
             self::markTestSkipped('Doctrine Version 2 is not installed, skipping test.');

--- a/test/DoctrineMigrationTest.php
+++ b/test/DoctrineMigrationTest.php
@@ -119,6 +119,52 @@ class DoctrineMigrationTest extends TestCase
         new DoctrineMigration(new \stdClass());
     }
 
+    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion3()
+    {
+        if (! $this->isDoctrineVersion3Installed()) {
+            self::markTestSkipped('Doctrine Version 3 is not installed, skipping test.');
+        }
+
+        $dependencyFactory = $this->getMockBuilder(DependencyFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dependencyFactory
+            ->expects(self::never())
+            ->method('getMigrationRepository');
+
+        $dependencyFactory
+            ->expects(self::never())
+            ->method('getMetadataStorage');
+
+        new DoctrineMigration($dependencyFactory);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion2()
+    {
+        if (! $this->isDoctrineVersion2Installed()) {
+            self::markTestSkipped('Doctrine Version 2 is not installed, skipping test.');
+        }
+
+        $configuration = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configuration
+            ->expects(self::never())
+            ->method('getAvailableVersions');
+
+        $configuration
+            ->expects(self::never())
+            ->method('getMigratedVersions');
+
+        new DoctrineMigration($configuration);
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function provideMigrationTestCases(): Generator
     {
         yield 'everything migrated' => [


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fetching the migrated versions in the constructor caused an unnecessary database connection as reported here: https://github.com/liip/LiipMonitorBundle/issues/259. This PR moves the logic from the constructor into the check method.