### PR TITLE
Compatibility with php-amqplib v3.0.0

### DIFF
--- a/src/Check/RabbitMQ.php
+++ b/src/Check/RabbitMQ.php
@@ -10,7 +10,7 @@ namespace Laminas\Diagnostics\Check;
 
 use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 /**
  * Validate that a RabbitMQ service is running
@@ -71,11 +71,11 @@ class RabbitMQ extends AbstractCheck
      */
     public function check()
     {
-        if (! class_exists('PhpAmqpLib\Connection\AMQPConnection')) {
+        if (! class_exists('PhpAmqpLib\Connection\AMQPStreamConnection')) {
             return new Failure('PhpAmqpLib is not installed');
         }
 
-        $conn = new AMQPConnection(
+        $conn = new AMQPStreamConnection(
             $this->host,
             $this->port,
             $this->user,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`AMQPConnection` has been removed in v3.0.0 of the PhpAmqpLib library and this causes an error where the check shows that PhpAmqpLib is not installed. I've changed the check to use  `AMQPStreamConnection` that has been added to PhpAmqpLib in v2.0.2 that was released in 2013.