### PR TITLE
Add `@throws` tag to `CheckInterface::check()`

### DIFF
--- a/src/Check/CheckInterface.php
+++ b/src/Check/CheckInterface.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Diagnostics\Check;
 
+use Exception;
 use Laminas\Diagnostics\Result\ResultInterface;
 
 interface CheckInterface
@@ -16,6 +17,7 @@ interface CheckInterface
      * Perform the actual check and return a ResultInterface
      *
      * @return ResultInterface
+     * @throws Exception
      */
     public function check();
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

In `CheckInterface::check()` it is also possible to throw an exception
instead of returning an object of type `ResultInterface`. This exception
is then converted to a `Failure` in `Runner::run()`. This should be
reflected in the PHPDoc via a throws tag in my opinion.

This also has the advantage that e.g. PhpStorm does not show a warning
if you intentionally do not catch an exception in your own checker.

Signed-off-by: Yannick Ihmels <yannick@ihmels.org>