### PR TITLE
[HttpService] Fix ssl:// and tls:// support

### DIFF
--- a/src/Check/HttpService.php
+++ b/src/Check/HttpService.php
@@ -71,8 +71,10 @@ class HttpService extends AbstractCheck
             ));
         }
 
+        $headerHost = preg_replace('/^((?:ssl|tls):\/\/)/', '', $this->host);
+
         $header = "GET {$this->path} HTTP/1.0\r\n";
-        $header .= "Host: {$this->host}\r\n";
+        $header .= "Host: $headerHost\r\n";
         $header .= "Connection: close\r\n\r\n";
         fputs($fp, $header);
         $str = '';


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

`fsockopen` supports SSL connection if the hostname is prefixed with `ssl://` or `tls://`. In this case, we need to remove the prefix before using the value for the http request.