### PR TITLE
Move constructor code into check

### DIFF
--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -27,11 +27,6 @@ class SecurityAdvisory extends AbstractCheck
     protected $advisoryAnalyzer = null;
 
     /**
-     * @var \Enlightn\SecurityChecker\AdvisoryFetcher null
-     */
-    protected $advisoryFetcher = null;
-
-    /**
      * @param  string $lockFilePath Path to composer.lock
      * @throws InvalidArgumentException
      */
@@ -69,7 +64,8 @@ class SecurityAdvisory extends AbstractCheck
     public function check()
     {
         if ($this->advisoryAnalyzer === null) {
-            $parser = new AdvisoryParser($this->downloadAdvisoriesAndReturnPath());
+            $advisoriesDirectory = (new AdvisoryFetcher())->fetchAdvisories();
+            $parser = new AdvisoryParser($advisoriesDirectory);
 
             $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());
         }
@@ -107,18 +103,5 @@ class SecurityAdvisory extends AbstractCheck
             'There are currently no security advisories for packages specified in %s',
             $this->lockFilePath
         ));
-    }
-
-    /**
-     * @return string
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    private function downloadAdvisoriesAndReturnPath(): string
-    {
-        if ($this->advisoryFetcher === null) {
-            $this->advisoryFetcher = new AdvisoryFetcher();
-        }
-
-        return $this->advisoryFetcher->fetchAdvisories();
     }
 }

--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -60,7 +60,7 @@ class SecurityAdvisory extends AbstractCheck
 
     public function check()
     {
-        if($this->advisoryAnalyzer === null) {
+        if ($this->advisoryAnalyzer === null) {
             $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
 
             $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());

--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -115,7 +115,7 @@ class SecurityAdvisory extends AbstractCheck
      */
     private function downloadAdvisoriesAndReturnPath(): string
     {
-        if($this->advisoryFetcher === null) {
+        if ($this->advisoryFetcher === null) {
             $this->advisoryFetcher = new AdvisoryFetcher();
         }
 

--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -72,7 +72,9 @@ class SecurityAdvisory extends AbstractCheck
                     'Cannot find composer lock file at %s',
                     $this->lockFilePath
                 ), $this->lockFilePath);
-            } elseif (! is_readable($this->lockFilePath)) {
+            }
+
+            if (! is_readable($this->lockFilePath)) {
                 return new Failure(sprintf(
                     'Cannot open composer lock file at %s',
                     $this->lockFilePath

--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -56,14 +56,14 @@ class SecurityAdvisory extends AbstractCheck
         }
 
         $this->lockFilePath    = $lockFilePath;
-
-        $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
-
-        $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());
     }
 
     public function check()
     {
+        $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
+
+        $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());
+
         try {
             if (! file_exists($this->lockFilePath) || ! is_file($this->lockFilePath)) {
                 return new Failure(sprintf(

--- a/src/Check/SecurityAdvisory.php
+++ b/src/Check/SecurityAdvisory.php
@@ -22,9 +22,9 @@ class SecurityAdvisory extends AbstractCheck
     protected $lockFilePath;
 
     /**
-     * @var \Enlightn\SecurityChecker\AdvisoryAnalyzer
+     * @var \Enlightn\SecurityChecker\AdvisoryAnalyzer|null
      */
-    protected $advisoryAnalyzer;
+    protected $advisoryAnalyzer = null;
 
     /**
      * @param  string $lockFilePath Path to composer.lock
@@ -60,9 +60,11 @@ class SecurityAdvisory extends AbstractCheck
 
     public function check()
     {
-        $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
+        if($this->advisoryAnalyzer === null) {
+            $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
 
-        $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());
+            $this->advisoryAnalyzer = new AdvisoryAnalyzer($parser->getAdvisories());
+        }
 
         try {
             if (! file_exists($this->lockFilePath) || ! is_file($this->lockFilePath)) {

--- a/test/ChecksTest.php
+++ b/test/ChecksTest.php
@@ -647,22 +647,6 @@ class ChecksTest extends TestCase
         self::assertInstanceOf(Success::class, $result);
     }
 
-    /**
-     * @depends testSecurityAdvisory
-     */
-    public function testSecurityAdvisoryFetcherException(): void
-    {
-        $secureComposerLock = __DIR__ . '/TestAsset/secure-composer.lock';
-        $fetcher = $this->createMock(AdvisoryFetcher::class);
-        $fetcher->expects($this->once())
-            ->method('fetchAdvisories')
-            ->will(self::throwException(new \UnexpectedValueException()));
-        $check = new SecurityAdvisory($secureComposerLock);
-        $check->setAdvisoryFetcher($fetcher);
-        $this->expectException(\UnexpectedValueException::class);
-        $check->check();
-    }
-
     public function testPhpVersionInvalidVersion(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/test/ChecksTest.php
+++ b/test/ChecksTest.php
@@ -4,6 +4,7 @@ namespace LaminasTest\Diagnostics;
 
 use ArrayObject;
 use Enlightn\SecurityChecker\AdvisoryAnalyzer;
+use Enlightn\SecurityChecker\AdvisoryFetcher;
 use ErrorException;
 use Exception;
 use InvalidArgumentException;
@@ -644,6 +645,22 @@ class ChecksTest extends TestCase
         $check->setAdvisoryAnalyzer($checker);
         $result = $check->check();
         self::assertInstanceOf(Success::class, $result);
+    }
+
+    /**
+     * @depends testSecurityAdvisory
+     */
+    public function testSecurityAdvisoryFetcherException(): void
+    {
+        $secureComposerLock = __DIR__ . '/TestAsset/secure-composer.lock';
+        $fetcher = $this->createMock(AdvisoryFetcher::class);
+        $fetcher->expects($this->once())
+            ->method('fetchAdvisories')
+            ->will(self::throwException(new \UnexpectedValueException()));
+        $check = new SecurityAdvisory($secureComposerLock);
+        $check->setAdvisoryFetcher($fetcher);
+        $this->expectException(\UnexpectedValueException::class);
+        $check->check();
     }
 
     public function testPhpVersionInvalidVersion(): void

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -4,7 +4,6 @@ namespace LaminasTest\Diagnostics\TestAsset\Check;
 
 use Laminas\Diagnostics\Check\SecurityAdvisory as BaseCheck;
 use Enlightn\SecurityChecker\AdvisoryAnalyzer;
-use Enlightn\SecurityChecker\AdvisoryFetcher;
 
 class SecurityAdvisory extends BaseCheck
 {
@@ -16,11 +15,4 @@ class SecurityAdvisory extends BaseCheck
         $this->advisoryAnalyzer = $advisoryAnalyzer;
     }
 
-    /**
-     * @param \Enlightn\SecurityChecker\AdvisoryFetcher $advisoryFetcher
-     */
-    public function setAdvisoryFetcher(AdvisoryFetcher $advisoryFetcher): void
-    {
-        $this->advisoryFetcher = $advisoryFetcher;
-    }
 }

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -23,6 +23,4 @@ class SecurityAdvisory extends BaseCheck
     {
         $this->advisoryFetcher = $advisoryFetcher;
     }
-
-
 }

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -4,14 +4,25 @@ namespace LaminasTest\Diagnostics\TestAsset\Check;
 
 use Laminas\Diagnostics\Check\SecurityAdvisory as BaseCheck;
 use Enlightn\SecurityChecker\AdvisoryAnalyzer;
+use Enlightn\SecurityChecker\AdvisoryFetcher;
 
 class SecurityAdvisory extends BaseCheck
 {
     /**
      * @param \Enlightn\SecurityChecker\AdvisoryAnalyzer $advisoryAnalyzer
      */
-    public function setAdvisoryAnalyzer(AdvisoryAnalyzer $advisoryAnalyzer)
+    public function setAdvisoryAnalyzer(AdvisoryAnalyzer $advisoryAnalyzer): void
     {
         $this->advisoryAnalyzer = $advisoryAnalyzer;
     }
+
+    /**
+     * @param \Enlightn\SecurityChecker\AdvisoryFetcher $advisoryFetcher
+     */
+    public function setAdvisoryFetcher(AdvisoryFetcher $advisoryFetcher): void
+    {
+        $this->advisoryFetcher = $advisoryFetcher;
+    }
+
+
 }

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -14,5 +14,4 @@ class SecurityAdvisory extends BaseCheck
     {
         $this->advisoryAnalyzer = $advisoryAnalyzer;
     }
-
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes


This moves the instantiation of the AdvisoryAnalyzer into the check function to make sure we only download the advisories when actually checking them. 
Closes #28 