### PR TITLE
PHP 8.1 compatibility (SplObjectStorage)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
          verbose="true">
     <testsuites>
         <testsuite name="laminas-diagnostics">

--- a/src/Result/Collection.php
+++ b/src/Result/Collection.php
@@ -100,6 +100,7 @@ class Collection extends \SplObjectStorage
      * @return mixed
      * @link http://php.net/manual/en/splobjectstorage.offsetget.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($index)
     {
         $this->validateIndex($index);
@@ -112,6 +113,7 @@ class Collection extends \SplObjectStorage
      * @return bool
      * @link http://php.net/manual/en/splobjectstorage.offsetexists.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($index)
     {
         $this->validateIndex($index);
@@ -124,6 +126,7 @@ class Collection extends \SplObjectStorage
      * @param mixed|null $checkResult
      * @link http://php.net/manual/en/splobjectstorage.offsetset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($index, $checkResult = null)
     {
         $this->validateIndex($index);
@@ -145,6 +148,7 @@ class Collection extends \SplObjectStorage
      * @param object $index
      * @link http://php.net/manual/en/splobjectstorage.offsetunset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($index)
     {
         $this->validateIndex($index);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

`Laminas\Diagnostics\Result\Collection` implements `SplObjectStorage` and throws deprecation notices when executed under PHP 8.1.

This PR provides changes to remove deprecation warnings within support PHP versions.