### PR TITLE
Document `void` return types of `Collection#offsetSet()` and `Collection#offsetUnset()`

### DIFF
--- a/src/Result/Collection.php
+++ b/src/Result/Collection.php
@@ -124,6 +124,7 @@ class Collection extends \SplObjectStorage
     /**
      * @param object     $index
      * @param mixed|null $checkResult
+     * @return void
      * @link http://php.net/manual/en/splobjectstorage.offsetset.php
      */
     #[\ReturnTypeWillChange]
@@ -146,6 +147,7 @@ class Collection extends \SplObjectStorage
 
     /**
      * @param object $index
+     * @return void
      * @link http://php.net/manual/en/splobjectstorage.offsetunset.php
      */
     #[\ReturnTypeWillChange]


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Follow-up to https://github.com/laminas/laminas-diagnostics/pull/31

See https://github.com/symfony/symfony/issues/44929#issuecomment-1006407389, the `#[\ReturnTypeWillChange]` attribute is not enough for Symfony's ErrorHandler.