### PR TITLE
Update to laminas-coding-standard v2 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.phpcs-cache
+/.phpunit.cache/
 /clover.xml
 /coveralls-upload.json
 /docs/html/

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {
@@ -33,7 +36,7 @@
         "doctrine/migrations": "^2.0 || ^3.0",
         "enlightn/security-checker": "^1.2",
         "guzzlehttp/guzzle": "^7.2",
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-loader": "^2.0",
         "mikey179/vfsstream": "dev-master#08a798577d677436f4f4ea3d0b3c949f64655548 as 1.6.9",
         "php-amqplib/php-amqplib": "^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d64438c0f82f1607b88001c0b3ab997a",
+    "content-hash": "1aabc77310fc2e3dac49b4dbde974d79",
     "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.5.2",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6.0.9 | ^7",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
                 "psalm/phar": "^3.11@dev",
                 "react/promise": "^2"
             },
@@ -40,13 +40,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\": "lib"
-                },
                 "files": [
                     "lib/functions.php",
                     "lib/Internal/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -71,7 +71,7 @@
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
-            "homepage": "http://amphp.org/amp",
+            "homepage": "https://amphp.org/amp",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -86,7 +86,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+                "source": "https://github.com/amphp/amp/tree/v2.6.2"
             },
             "funding": [
                 {
@@ -94,7 +94,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-10T17:06:37+00:00"
+            "time": "2022-02-20T17:52:18+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -129,12 +129,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
-                },
                 "files": [
                     "lib/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -175,16 +175,16 @@
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.2",
+            "version": "1.11.99.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
             },
             "funding": [
                 {
@@ -244,27 +244,98 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-24T07:46:03+00:00"
+            "time": "2022-01-17T14:14:24+00:00"
         },
         {
-            "name": "composer/semver",
-            "version": "3.2.5",
+            "name": "composer/pcre",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T20:21:48+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/5d8e574bb0e69188786b8ef77d43341222a41a71",
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.54",
+                "phpstan/phpstan": "^1.4",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
@@ -309,7 +380,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.5"
+                "source": "https://github.com/composer/semver/tree/3.3.1"
             },
             "funding": [
                 {
@@ -325,29 +396,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-24T12:41:47+00:00"
+            "time": "2022-03-16T11:22:07+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -373,7 +446,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -389,7 +462,82 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-05T19:37:51+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -430,24 +578,23 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88"
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/c9622c6820d3ede1e2315a6a377ea1076e421d88",
-                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/331b4d5dbaeab3827976273e9356b3b453c300ce",
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.1 || ^8.0"
             },
             "conflict": {
-                "doctrine/common": ">2.2,<2.4",
-                "psr/cache": ">=3"
+                "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
@@ -456,8 +603,9 @@
                 "mongodb/mongodb": "^1.1",
                 "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
                 "predis/predis": "~1.0",
-                "psr/cache": "^1.0 || ^2.0",
-                "symfony/cache": "^4.4 || ^5.2"
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
+                "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
             },
             "suggest": {
                 "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
@@ -509,7 +657,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/2.0.3"
+                "source": "https://github.com/doctrine/cache/tree/2.1.1"
             },
             "funding": [
                 {
@@ -525,38 +673,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-25T09:43:04+00:00"
+            "time": "2021-07-17T14:49:29+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.2",
+            "version": "3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "8dd39d2ead4409ce652fd4f02621060f009ea5e4"
+                "reference": "83f779beaea1893c0bece093ab2104c6d15a7f26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/8dd39d2ead4409ce652fd4f02621060f009ea5e4",
-                "reference": "8dd39d2ead4409ce652fd4f02621060f009ea5e4",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/83f779beaea1893c0bece093ab2104c6d15a7f26",
+                "reference": "83f779beaea1893c0bece093ab2104c6d15a7f26",
                 "shasum": ""
             },
             "require": {
-                "doctrine/cache": "^1.0|^2.0",
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/deprecations": "^0.5.3",
                 "doctrine/event-manager": "^1.0",
-                "ext-pdo": "*",
-                "php": "^7.1 || ^8"
+                "php": "^7.3 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
             },
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
-                "jetbrains/phpstorm-stubs": "2020.2",
-                "phpstan/phpstan": "0.12.81",
-                "phpunit/phpunit": "^7.5.20|^8.5|9.5.5",
-                "squizlabs/php_codesniffer": "3.6.0",
-                "symfony/cache": "^4.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.6.4"
+                "jetbrains/phpstorm-stubs": "2021.1",
+                "phpstan/phpstan": "1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "9.5.16",
+                "psalm/plugin-phpunit": "0.16.1",
+                "squizlabs/php_codesniffer": "3.6.2",
+                "symfony/cache": "^5.2|^6.0",
+                "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
+                "vimeo/psalm": "4.22.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -567,7 +719,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                    "Doctrine\\DBAL\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -610,14 +762,13 @@
                 "queryobject",
                 "sasql",
                 "sql",
-                "sqlanywhere",
                 "sqlite",
                 "sqlserver",
                 "sqlsrv"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.2"
+                "source": "https://github.com/doctrine/dbal/tree/3.3.4"
             },
             "funding": [
                 {
@@ -633,7 +784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-18T21:48:39+00:00"
+            "time": "2022-03-20T18:37:29+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -774,29 +925,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -823,7 +975,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -839,32 +991,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.2.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "072c11c1dcfced4505e29a0487b06ea774c403f4"
+                "reference": "e7df670aa9565b435ffec636cebdb4d0a1987f10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/072c11c1dcfced4505e29a0487b06ea774c403f4",
-                "reference": "072c11c1dcfced4505e29a0487b06ea774c403f4",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/e7df670aa9565b435ffec636cebdb4d0a1987f10",
+                "reference": "e7df670aa9565b435ffec636cebdb4d0a1987f10",
                 "shasum": ""
             },
             "require": {
-                "composer/package-versions-deprecated": "^1.8",
-                "doctrine/dbal": "^2.11",
+                "composer-runtime-api": "^2",
+                "doctrine/dbal": "^2.11 || ^3.0",
                 "doctrine/deprecations": "^0.5.3",
                 "doctrine/event-manager": "^1.0",
                 "friendsofphp/proxy-manager-lts": "^1.0",
                 "php": "^7.2 || ^8.0",
-                "psr/log": "^1.1.3",
-                "symfony/console": "^3.4 || ^4.4.16 || ^5.0",
-                "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0"
+                "psr/log": "^1.1.3 || ^2 || ^3",
+                "symfony/console": "^3.4 || ^4.4.16 || ^5.0 || ^6.0",
+                "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^8.0",
@@ -879,9 +1031,9 @@
                 "phpstan/phpstan-strict-rules": "^0.12",
                 "phpstan/phpstan-symfony": "^0.12",
                 "phpunit/phpunit": "^8.5 || ^9.4",
-                "symfony/cache": "^5.3",
-                "symfony/process": "^3.4 || ^4.0 || ^5.0",
-                "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
+                "symfony/cache": "^3.4.26 || ^4.2.12 || ^5.0 || ^6.0",
+                "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0"
             },
             "suggest": {
                 "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
@@ -929,7 +1081,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.2.0"
+                "source": "https://github.com/doctrine/migrations/tree/3.4.1"
             },
             "funding": [
                 {
@@ -945,34 +1097,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-05T07:06:31+00:00"
+            "time": "2022-01-28T21:58:35+00:00"
         },
         {
             "name": "enlightn/security-checker",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/enlightn/security-checker.git",
-                "reference": "dc5bce653fa4d9c792e9dcffa728c0642847c1e1"
+                "reference": "196bacc76e7a72a63d0e1220926dbb190272db97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/dc5bce653fa4d9c792e9dcffa728c0642847c1e1",
-                "reference": "dc5bce653fa4d9c792e9dcffa728c0642847c1e1",
+                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/196bacc76e7a72a63d0e1220926dbb190272db97",
+                "reference": "196bacc76e7a72a63d0e1220926dbb190272db97",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/guzzle": "^6.3|^7.0",
                 "php": ">=5.6",
-                "symfony/console": "^3.4|^4|^5",
-                "symfony/finder": "^3|^4|^5",
-                "symfony/process": "^3.4|^4|^5",
-                "symfony/yaml": "^3.4|^4|^5"
+                "symfony/console": "^3.4|^4|^5|^6",
+                "symfony/finder": "^3|^4|^5|^6",
+                "symfony/process": "^3.4|^4|^5|^6",
+                "symfony/yaml": "^3.4|^4|^5|^6"
             },
             "require-dev": {
                 "ext-zip": "*",
-                "friendsofphp/php-cs-fixer": "^2.18",
+                "friendsofphp/php-cs-fixer": "^2.18|^3.0",
                 "phpunit/phpunit": "^5.5|^6|^7|^8|^9"
             },
             "bin": [
@@ -1009,9 +1161,9 @@
             ],
             "support": {
                 "issues": "https://github.com/enlightn/security-checker/issues",
-                "source": "https://github.com/enlightn/security-checker/tree/v1.9.0"
+                "source": "https://github.com/enlightn/security-checker/tree/v1.10.0"
             },
-            "time": "2021-05-06T09:03:35+00:00"
+            "time": "2022-02-21T22:40:16+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1116,16 +1268,16 @@
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
-            "version": "v1.0.5",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/proxy-manager-lts.git",
-                "reference": "006aa5d32f887a4db4353b13b5b5095613e0611f"
+                "reference": "c828ced1f932094ab79e4120a106a666565e4d9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/006aa5d32f887a4db4353b13b5b5095613e0611f",
-                "reference": "006aa5d32f887a4db4353b13b5b5095613e0611f",
+                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/c828ced1f932094ab79e4120a106a666565e4d9c",
+                "reference": "c828ced1f932094ab79e4120a106a666565e4d9c",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1294,7 @@
             },
             "require-dev": {
                 "ext-phar": "*",
-                "symfony/phpunit-bridge": "^5.2|^6.0"
+                "symfony/phpunit-bridge": "^5.4|^6.0"
             },
             "type": "library",
             "extra": {
@@ -1164,7 +1316,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.io/"
+                    "homepage": "https://ocramius.github.io/"
                 },
                 {
                     "name": "Nicolas Grekas",
@@ -1182,7 +1334,7 @@
             ],
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/proxy-manager-lts/issues",
-                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.5"
+                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -1194,28 +1346,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-22T16:11:15+00:00"
+            "time": "2022-03-02T09:29:19+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.3.0",
+            "version": "7.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
-                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ac1ec1cd9b5624694c3a40be801d94137afb12b4",
+                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.4",
-                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
                 "php": "^7.2.5 || ^8.0",
-                "psr/http-client": "^1.0"
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1225,7 +1378,7 @@
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "^3.0",
                 "phpunit/phpunit": "^8.5.5 || ^9.3.5",
-                "psr/log": "^1.1"
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
                 "ext-curl": "Required for CURL handler support",
@@ -1235,7 +1388,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.3-dev"
+                    "dev-master": "7.4-dev"
                 }
             },
             "autoload": {
@@ -1252,18 +1405,42 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
                     "name": "Márk Sági-Kazár",
                     "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
                 "curl",
@@ -1277,7 +1454,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.2"
             },
             "funding": [
                 {
@@ -1289,28 +1466,24 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/alexeyshockov",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/gmponos",
-                    "type": "github"
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T11:33:13+00:00"
+            "time": "2022-03-20T14:16:28+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.4.1",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
-                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
                 "shasum": ""
             },
             "require": {
@@ -1322,16 +1495,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1339,9 +1512,24 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
             "description": "Guzzle promises library",
@@ -1350,35 +1538,52 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+                "source": "https://github.com/guzzle/promises/tree/1.5.1"
             },
-            "time": "2021-03-07T09:25:29+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T20:56:57+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.2",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c94a94f120803a18554c1805ef2e539f8285f9a2",
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1386,16 +1591,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1403,13 +1605,39 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
                     "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "PSR-7 message implementation that also provides common utility methods",
@@ -1425,22 +1653,36 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.2.1"
             },
-            "time": "2021-04-26T09:17:50+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-20T21:55:58+00:00"
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.5.0",
+            "version": "4.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "c99ef8e5629c33bfaa3a8f1df773e916af564cd6"
+                "reference": "6fd96d4d913571a2cd056a27b123fa28cb90ac4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/c99ef8e5629c33bfaa3a8f1df773e916af564cd6",
-                "reference": "c99ef8e5629c33bfaa3a8f1df773e916af564cd6",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/6fd96d4d913571a2cd056a27b123fa28cb90ac4e",
+                "reference": "6fd96d4d913571a2cd056a27b123fa28cb90ac4e",
                 "shasum": ""
             },
             "require": {
@@ -1461,12 +1703,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Laminas\\Code\\": "src/"
-                },
                 "files": [
                     "polyfill/ReflectionEnumPolyfill.php"
-                ]
+                ],
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1493,35 +1735,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-07T06:00:32+00:00"
+            "time": "2021-12-19T18:06:55+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1535,7 +1782,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -1592,68 +1845,6 @@
                 }
             ],
             "time": "2021-09-02T18:30:53+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -1714,41 +1905,42 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2021-05-10T05:01:00+00:00"
+            "time": "2022-02-23T02:40:26+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1764,7 +1956,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -1772,7 +1964,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1827,16 +2019,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.11.0",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -1877,9 +2069,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-07-03T13:36:55+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1936,16 +2128,16 @@
         },
         {
             "name": "paragonie/constant_time_encoding",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c"
+                "reference": "9229e15f2e6ba772f0c55dd6986c563b937170a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
-                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/9229e15f2e6ba772f0c55dd6986c563b937170a8",
+                "reference": "9229e15f2e6ba772f0c55dd6986c563b937170a8",
                 "shasum": ""
             },
             "require": {
@@ -1999,7 +2191,7 @@
                 "issues": "https://github.com/paragonie/constant_time_encoding/issues",
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
-            "time": "2020-12-06T15:14:20+00:00"
+            "time": "2022-01-17T05:32:27+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2053,16 +2245,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -2107,22 +2299,22 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -2158,22 +2350,22 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "php-amqplib/php-amqplib",
-            "version": "v3.1.0",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-amqplib/php-amqplib.git",
-                "reference": "c8812f783fe8714a8a8e387003fb297aded7f974"
+                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/c8812f783fe8714a8a8e387003fb297aded7f974",
-                "reference": "c8812f783fe8714a8a8e387003fb297aded7f974",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/0bec5b392428e0ac3b3f34fbc4e02d706995833e",
+                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e",
                 "shasum": ""
             },
             "require": {
@@ -2239,9 +2431,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-amqplib/php-amqplib/issues",
-                "source": "https://github.com/php-amqplib/php-amqplib/tree/v3.1.0"
+                "source": "https://github.com/php-amqplib/php-amqplib/tree/v3.2.0"
             },
-            "time": "2021-10-22T16:37:06+00:00"
+            "time": "2022-03-10T19:16:00+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2298,16 +2490,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -2318,7 +2510,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2348,22 +2541,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -2371,7 +2564,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2397,22 +2591,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.9",
+            "version": "3.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7"
+                "reference": "1443ab79364eea48665fa8c09ac67f37d1025f7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/a127a5133804ff2f47ae629dd529b129da616ad7",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/1443ab79364eea48665fa8c09ac67f37d1025f7e",
+                "reference": "1443ab79364eea48665fa8c09ac67f37d1025f7e",
                 "shasum": ""
             },
             "require": {
@@ -2494,7 +2688,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.9"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.13"
             },
             "funding": [
                 {
@@ -2510,20 +2704,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-14T06:54:45+00:00"
+            "time": "2022-01-30T08:50:05+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -2575,9 +2769,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -2632,24 +2826,68 @@
             "time": "2020-07-09T08:33:42+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.6",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "05333065c88f9518e08b094bdd10a4a9e538b2d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/05333065c88f9518e08b094bdd10a4a9e538b2d4",
+                "reference": "05333065c88f9518e08b094bdd10a4a9e538b2d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.4.1"
+            },
+            "time": "2022-03-29T09:28:16+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2698,7 +2936,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -2706,20 +2944,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-28T07:26:59+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -2758,7 +2996,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -2766,7 +3004,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2951,16 +3189,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.6",
+            "version": "9.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35ea4b7f3acabb26f4bb640f8c30866c401da807",
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807",
                 "shasum": ""
             },
             "require": {
@@ -2972,11 +3210,11 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2990,7 +3228,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -3011,11 +3249,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3038,11 +3276,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.19"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -3050,20 +3288,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-23T05:14:38+00:00"
+            "time": "2022-03-15T09:57:31+00:00"
         },
         {
             "name": "predis/predis",
-            "version": "v1.1.7",
+            "version": "v1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/predis/predis.git",
-                "reference": "b240daa106d4e02f0c5b7079b41e31ddf66fddf8"
+                "reference": "a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/predis/predis/zipball/b240daa106d4e02f0c5b7079b41e31ddf66fddf8",
-                "reference": "b240daa106d4e02f0c5b7079b41e31ddf66fddf8",
+                "url": "https://api.github.com/repos/predis/predis/zipball/a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e",
+                "reference": "a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e",
                 "shasum": ""
             },
             "require": {
@@ -3108,7 +3346,7 @@
             ],
             "support": {
                 "issues": "https://github.com/predis/predis/issues",
-                "source": "https://github.com/predis/predis/tree/v1.1.7"
+                "source": "https://github.com/predis/predis/tree/v1.1.10"
             },
             "funding": [
                 {
@@ -3116,7 +3354,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-04T19:34:46+00:00"
+            "time": "2022-01-05T17:46:08+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3179,21 +3417,70 @@
             "time": "2021-05-29T19:11:38+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.1.1",
+            "name": "psr/cache",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -3222,9 +3509,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-client",
@@ -3277,6 +3564,61 @@
                 "source": "https://github.com/php-fig/http-client/tree/master"
             },
             "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -3854,16 +4196,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -3912,14 +4254,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -3927,20 +4269,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -3983,7 +4325,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -3991,7 +4333,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4282,28 +4624,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4326,7 +4668,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4334,7 +4676,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4390,64 +4732,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.4.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.2",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.5.2",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.0",
+                "phpstan/phpstan-strict-rules": "1.1.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.19"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-29T12:44:16+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4460,7 +4836,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -4470,32 +4846,33 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.2",
+            "version": "v5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+                "reference": "d8111acc99876953f52fe16d4c50eb60940d49ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d8111acc99876953f52fe16d4c50eb60940d49ad",
+                "reference": "d8111acc99876953f52fe16d4c50eb60940d49ad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -4503,16 +4880,16 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -4552,7 +4929,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.2"
+                "source": "https://github.com/symfony/console/tree/v5.4.5"
             },
             "funding": [
                 {
@@ -4568,20 +4945,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-12T09:42:48+00:00"
+            "time": "2022-02-24T12:45:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
@@ -4590,7 +4967,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4619,7 +4996,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -4635,25 +5012,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2021-07-12T14:48:14+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.3.3",
+            "version": "v5.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9"
+                "reference": "d53a45039974952af7f7ebc461ccdd4295e29440"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/19b71c8f313b411172dd5f470fd61f24466d79a9",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d53a45039974952af7f7ebc461ccdd4295e29440",
+                "reference": "d53a45039974952af7f7ebc461ccdd4295e29440",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -4681,7 +5060,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.3.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.6"
             },
             "funding": [
                 {
@@ -4697,24 +5076,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-30T07:27:52+00:00"
+            "time": "2022-03-02T12:42:23+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.3.0",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
+                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/231313534dded84c7ecaa79d14bc5da4ccb69b7d",
+                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -4742,7 +5123,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.3.0"
+                "source": "https://github.com/symfony/finder/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4758,24 +5139,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T12:52:38+00:00"
+            "time": "2022-01-26T16:34:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -4791,12 +5175,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4821,7 +5205,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -4837,20 +5221,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
                 "shasum": ""
             },
             "require": {
@@ -4870,12 +5254,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4902,7 +5286,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -4918,11 +5302,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:17:38+00:00"
+            "time": "2021-11-23T21:10:46+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4951,12 +5335,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -4986,7 +5370,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -5006,20 +5390,23 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -5035,12 +5422,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5066,7 +5453,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -5082,20 +5469,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2021-11-30T18:21:41+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/cc5db0e22b3cb4111010e48785a97f670b350ca5",
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5",
                 "shasum": ""
             },
             "require": {
@@ -5112,12 +5499,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -5145,7 +5532,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -5161,20 +5548,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-06-05T21:20:04+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
                 "shasum": ""
             },
             "require": {
@@ -5191,12 +5578,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -5228,7 +5615,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -5244,25 +5631,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-03-04T08:16:47+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.3.2",
+            "version": "v5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "714b47f9196de61a196d86c4bad5f09201b307df"
+                "reference": "95440409896f90a5f85db07a32b517ecec17fa4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/714b47f9196de61a196d86c4bad5f09201b307df",
-                "reference": "714b47f9196de61a196d86c4bad5f09201b307df",
+                "url": "https://api.github.com/repos/symfony/process/zipball/95440409896f90a5f85db07a32b517ecec17fa4c",
+                "reference": "95440409896f90a5f85db07a32b517ecec17fa4c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -5290,7 +5677,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.3.2"
+                "source": "https://github.com/symfony/process/tree/v5.4.5"
             },
             "funding": [
                 {
@@ -5306,25 +5693,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-12T10:15:01+00:00"
+            "time": "2022-01-30T18:16:22+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -5332,7 +5723,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5369,7 +5760,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -5385,25 +5776,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T10:43:52+00:00"
+            "time": "2021-11-04T16:48:04+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.3.0",
+            "version": "v5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65"
+                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/313d02f59d6543311865007e5ff4ace05b35ee65",
-                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
+                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/service-contracts": "^1.0|^2"
+                "symfony/service-contracts": "^1|^2|^3"
             },
             "type": "library",
             "autoload": {
@@ -5431,7 +5822,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.4.5"
             },
             "funding": [
                 {
@@ -5447,20 +5838,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2022-02-18T16:06:09+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.3",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "url": "https://api.github.com/repos/symfony/string/zipball/92043b7d8383e48104e411bc9434b260dbeb5a10",
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10",
                 "shasum": ""
             },
             "require": {
@@ -5471,20 +5862,23 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "~1.15"
             },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -5514,7 +5908,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.3"
+                "source": "https://github.com/symfony/string/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5530,32 +5924,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-27T11:44:38+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.3.3",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229"
+                "reference": "e80f87d2c9495966768310fc531b487ce64237a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
-                "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e80f87d2c9495966768310fc531b487ce64237a2",
+                "reference": "e80f87d2c9495966768310fc531b487ce64237a2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<4.4"
+                "symfony/console": "<5.3"
             },
             "require-dev": {
-                "symfony/console": "^4.4|^5.0"
+                "symfony/console": "^5.3|^6.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -5589,7 +5983,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.3.3"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5605,20 +5999,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-24T08:13:00+00:00"
+            "time": "2022-01-26T16:32:32+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -5647,7 +6041,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -5655,20 +6049,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.8.1",
+            "version": "4.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69"
+                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f73f2299dbc59a3e6c4d66cff4605176e728ee69",
-                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
+                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
                 "shasum": ""
             },
             "require": {
@@ -5676,8 +6070,9 @@
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -5687,11 +6082,11 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.10.5",
+                "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -5709,12 +6104,12 @@
                 "psalm/plugin-phpunit": "^0.16",
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/process": "^4.3 || ^5.0",
-                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
-                "ext-igbinary": "^2.0.5"
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
             },
             "bin": [
                 "psalm",
@@ -5733,13 +6128,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Psalm\\": "src/Psalm/"
-                },
                 "files": [
                     "src/functions.php",
                     "src/spl_object_id.php"
-                ]
+                ],
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5758,9 +6153,64 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.8.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.22.0"
             },
-            "time": "2021-06-20T23:03:20+00:00"
+            "time": "2022-02-24T20:34:05+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.13"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-15T19:52:12+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5890,5 +6340,5 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <config name="php_version" value="70300"/>
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard except requiring script types -->
+    <rule ref="LaminasCodingStandard">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+    </rule>
+</ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
   <file src="src/Check/AbstractCheck.php">
     <MissingConstructor occurrences="4">
       <code>$label</code>
@@ -18,18 +18,14 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Check/AbstractFileCheck.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($files) &amp;&amp; ! $files instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$files</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
-      <code>$files</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$file</code>
@@ -47,8 +43,8 @@
       <code>AbstractMemoryCheck</code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="2">
-      <code>(int)$criticalThreshold</code>
-      <code>(int)$warningThreshold</code>
+      <code>(int) $criticalThreshold</code>
+      <code>(int) $warningThreshold</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/ApcFragmentation.php">
@@ -123,16 +119,15 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Check/ClassExists.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($classNames) &amp;&amp; ! $classNames instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$classNames</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$class</code>
-      <code>$classNames</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$missing</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
       <code>$class</code>
       <code>$missing[]</code>
@@ -184,17 +179,6 @@
       <code>2</code>
       <code>4</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$precision</code>
-    </MissingParamType>
-    <MixedArgument occurrences="3">
-      <code>$precision</code>
-      <code>$precision</code>
-      <code>$precision + 6</code>
-    </MixedArgument>
-    <MixedOperand occurrences="1">
-      <code>$precision</code>
-    </MixedOperand>
     <NullArgument occurrences="2">
       <code>null</code>
       <code>null</code>
@@ -202,12 +186,11 @@
     <NullableReturnStatement occurrences="1">
       <code>bcdiv(bcpow(bcadd($a, $b), 2), bcmul(4, $t), $precision)</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument occurrences="4">
       <code>$b</code>
       <code>$b</code>
       <code>$b</code>
       <code>$x</code>
-      <code>bcsqrt(2)</code>
     </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>CpuPerformance</code>
@@ -220,17 +203,17 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;dir</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($path) &amp;&amp; ! $path instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$path</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$dir</code>
       <code>$dir</code>
-      <code>$path</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$nonDirs</code>
+      <code>$unreadable</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="3">
       <code>$dir</code>
       <code>$nonDirs[]</code>
@@ -248,19 +231,19 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;dir</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($path) &amp;&amp; ! $path instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$path</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$dir</code>
       <code>$dir</code>
-      <code>$path</code>
       <code>current($nonDirs)</code>
       <code>current($unwritable)</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$nonDirs</code>
+      <code>$unwritable</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="3">
       <code>$dir</code>
       <code>$nonDirs[]</code>
@@ -289,6 +272,7 @@
       <code>$this-&gt;path</code>
       <code>$this-&gt;path</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1"/>
     <MixedAssignment occurrences="3">
       <code>$bytes</code>
       <code>$bytes</code>
@@ -340,9 +324,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/DoctrineMigration.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! $input instanceof DependencyFactory &amp;&amp; ! $input instanceof Configuration</code>
-    </DocblockTypeContradiction>
     <MixedInferredReturnType occurrences="2">
       <code>Version[]</code>
       <code>Version[]</code>
@@ -363,22 +344,20 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;extensions</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($extensionName) &amp;&amp; ! $extensionName instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$extensionName</code>
     </InvalidPropertyAssignmentValue>
-    <MissingPropertyType occurrences="1">
-      <code>$autoload</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$ext</code>
       <code>$ext</code>
       <code>$ext</code>
       <code>$ext</code>
-      <code>$extensionName</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$missing</code>
+      <code>$missing</code>
+      <code>$this-&gt;extensions</code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="1">
       <code>$versions[$ext]</code>
     </MixedArrayOffset>
@@ -392,9 +371,6 @@
       <code>$ext</code>
       <code>$ext</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$this-&gt;extensions</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>ExtensionLoaded</code>
     </PropertyNotSetInConstructor>
@@ -403,66 +379,43 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Check/GuzzleHttpService.php">
-    <DeprecatedFunction occurrences="3">
-      <code>stream_for($body)</code>
-      <code>stream_for(http_build_query($body, '', '&amp;'))</code>
-      <code>stream_for(json_encode($body))</code>
-    </DeprecatedFunction>
+    <DocblockTypeContradiction occurrences="2">
+      <code>$result instanceof Failure</code>
+      <code>$result instanceof Failure</code>
+    </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="2"/>
     <InvalidReturnType occurrences="2">
       <code>bool|FailureInterface</code>
       <code>bool|FailureInterface</code>
     </InvalidReturnType>
-    <MissingPropertyType occurrences="5">
-      <code>$content</code>
-      <code>$guzzle</code>
-      <code>$options</code>
-      <code>$request</code>
-      <code>$statusCode</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="6">
-      <code>$body</code>
-      <code>$response</code>
-      <code>$response</code>
-      <code>$this-&gt;content</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;statusCode</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$request</code>
-      <code>$response</code>
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>GuzzleRequestInterface</code>
-      <code>\Laminas\Diagnostics\Result\ResultInterface</code>
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="5">
-      <code>createRequest</code>
-      <code>getUrl</code>
-      <code>send</code>
-      <code>send</code>
-      <code>setBody</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$request</code>
-    </MixedReturnStatement>
+    <LessSpecificReturnStatement occurrences="3">
+      <code>$request-&gt;withBody(Utils::streamFor($body))</code>
+      <code>$request-&gt;withBody(Utils::streamFor(http_build_query($body, '', '&amp;')))</code>
+      <code>$request-&gt;withBody(Utils::streamFor(json_encode($body)))</code>
+    </LessSpecificReturnStatement>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$headers</code>
+    </MixedArgumentTypeCoercion>
+    <MoreSpecificReturnType occurrences="1">
+      <code>PsrRequestInterface</code>
+    </MoreSpecificReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>GuzzleHttpService</code>
     </PropertyNotSetInConstructor>
-    <UndefinedClass occurrences="1">
-      <code>Stream</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="7">
-      <code>GuzzleRequestInterface</code>
-      <code>PsrRequestInterface|GuzzleRequestInterface</code>
-      <code>\GuzzleHttp\Message\ResponseInterface|Psr\Http\Message\ResponseInterface</code>
-      <code>\Guzzle\Http\Client|\GuzzleHttp\Client</code>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$guzzle</code>
+    </PropertyTypeCoercion>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(int) $response-&gt;getStatusCode()</code>
+      <code>(int) $statusCode</code>
+    </RedundantCastGivenDocblockType>
+    <UndefinedDocblockClass occurrences="2">
       <code>bool|FailureInterface</code>
       <code>bool|FailureInterface</code>
-      <code>string|PsrRequestInterface|GuzzleRequestInterface</code>
     </UndefinedDocblockClass>
+    <UnusedParam occurrences="1">
+      <code>$options</code>
+    </UnusedParam>
   </file>
   <file src="src/Check/HttpService.php">
     <PossiblyNullPropertyAssignmentValue occurrences="2">
@@ -525,7 +478,7 @@
   </file>
   <file src="src/Check/Mongo.php">
     <MixedInferredReturnType occurrences="1">
-      <code>array|\Iterator</code>
+      <code>array|Iterator</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>listDBs</code>
@@ -539,7 +492,7 @@
       <code>Mongo</code>
     </PropertyNotSetInConstructor>
     <UndefinedDocblockClass occurrences="2">
-      <code>\MongoConnectionException</code>
+      <code>MongoConnectionException</code>
       <code>\MongoDB\Driver\Exception</code>
     </UndefinedDocblockClass>
   </file>
@@ -565,30 +518,18 @@
       <code>OpCacheMemory</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Check/PDOCheck.php">
-    <MissingPropertyType occurrences="4">
-      <code>$dsn</code>
-      <code>$password</code>
-      <code>$timeout</code>
-      <code>$username</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="4">
-      <code>$this-&gt;dsn</code>
-      <code>$this-&gt;dsn</code>
-      <code>$this-&gt;password</code>
-      <code>$this-&gt;username</code>
-    </MixedArgument>
-  </file>
   <file src="src/Check/PhpFlag.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>$settingName instanceof Traversable</code>
+    <DocblockTypeContradiction occurrences="2">
       <code>is_array($settingName)</code>
       <code>is_scalar($expectedValue)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$name</code>
-      <code>$settingName</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$failures</code>
+      <code>$this-&gt;settings</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
       <code>$failures[]</code>
       <code>$name</code>
@@ -601,15 +542,14 @@
       <code>PhpFlag</code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="1">
-      <code>(bool)$expectedValue</code>
+      <code>(bool) $expectedValue</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/PhpVersion.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;operator</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="3">
-      <code>$expectedVersion instanceof \Traversable</code>
+    <DocblockTypeContradiction occurrences="2">
       <code>is_array($expectedVersion)</code>
       <code>is_scalar($operator)</code>
     </DocblockTypeContradiction>
@@ -621,8 +561,7 @@
       <code>$expectedVersion</code>
       <code>[$expectedVersion]</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="3">
-      <code>$expectedVersion</code>
+    <MixedArgument occurrences="2">
       <code>$version</code>
       <code>$version</code>
     </MixedArgument>
@@ -680,13 +619,13 @@
       <code>Redis</code>
     </PropertyNotSetInConstructor>
     <UndefinedClass occurrences="2">
+      <code>RedisException</code>
       <code>RedisExtensionClient</code>
-      <code>\RedisException</code>
     </UndefinedClass>
     <UndefinedDocblockClass occurrences="3">
       <code>$this-&gt;createClient()</code>
       <code>PredisClient|RedisExtensionClient</code>
-      <code>\RedisException</code>
+      <code>RedisException</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Check/SecurityAdvisory.php">
@@ -696,35 +635,33 @@
     <MixedArgument occurrences="1">
       <code>$advisories</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$advisories</code>
+      <code>$advisoriesDirectory</code>
     </MixedAssignment>
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecurityAdvisory</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Check/StreamWrapperExists.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_object($wrappers) &amp;&amp; ! $wrappers instanceof Traversable</code>
-    </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$wrappers</code>
     </InvalidPropertyAssignmentValue>
     <MissingClosureParamType occurrences="1">
       <code>$v</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$v</code>
-      <code>$wrappers</code>
       <code>current($missingWrappers)</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$missingWrappers</code>
+      <code>$this-&gt;wrappers</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
       <code>$class</code>
       <code>$missingWrappers[]</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$this-&gt;wrappers</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>StreamWrapperExists</code>
     </PropertyNotSetInConstructor>
@@ -805,45 +742,32 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Runner/Runner.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="1">
       <code>! is_array($checks) &amp;&amp; ! $checks instanceof Traversable</code>
-      <code>! is_array($config) &amp;&amp; ! $config instanceof Traversable</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>[$this, 'errorHandler']</code>
+    </InvalidArgument>
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;reporters</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
       <code>array</code>
     </InvalidReturnType>
-    <MissingParamType occurrences="5">
-      <code>$errfile</code>
-      <code>$errline</code>
-      <code>$errno</code>
-      <code>$errstr</code>
-      <code>$eventType</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType occurrences="8">
       <code>addCheck</code>
       <code>addChecks</code>
       <code>addReporter</code>
-      <code>errorHandler</code>
       <code>removeReporter</code>
       <code>setBreakOnFailure</code>
       <code>setCatchErrorSeverity</code>
       <code>startErrorHandler</code>
       <code>stopErrorHandler</code>
     </MissingReturnType>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="2">
       <code>$check</code>
-      <code>$errfile</code>
-      <code>$errline</code>
-      <code>$errno</code>
-      <code>$errstr</code>
       <code>$key</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>[$this, 'errorHandler']</code>
-    </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="1">
       <code>$results[$check]</code>
     </MixedArrayOffset>
@@ -890,44 +814,24 @@
     </UndefinedClass>
   </file>
   <file src="test/AbstractMemoryTest.php">
-    <MissingParamType occurrences="4">
-      <code>$criticalThreshold</code>
-      <code>$criticalThreshold</code>
-      <code>$warningThreshold</code>
-      <code>$warningThreshold</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>createCheck</code>
-    </MissingReturnType>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/ApcFragmentationTest.php">
-    <MissingParamType occurrences="2">
+    <InvalidScalarArgument occurrences="2">
       <code>$criticalThreshold</code>
       <code>$warningThreshold</code>
-    </MissingParamType>
-    <MixedArgument occurrences="2">
-      <code>$criticalThreshold</code>
-      <code>$warningThreshold</code>
-    </MixedArgument>
+    </InvalidScalarArgument>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/ApcMemoryTest.php">
-    <MissingParamType occurrences="2">
+    <InvalidScalarArgument occurrences="2">
       <code>$criticalThreshold</code>
       <code>$warningThreshold</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>createCheck</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$criticalThreshold</code>
-      <code>$warningThreshold</code>
-    </MixedArgument>
+    </InvalidScalarArgument>
   </file>
   <file src="test/BasicConsoleReporterTest.php">
     <InvalidScalarArgument occurrences="7">
@@ -967,11 +871,11 @@
       <code>[$this, 'foobarbar']</code>
       <code>[]</code>
       <code>fopen('php://memory', 'r')</code>
-      <code>new stdClass</code>
-      <code>new stdClass</code>
-      <code>new stdClass</code>
-      <code>new stdClass</code>
-      <code>new stdClass</code>
+      <code>new stdClass()</code>
+      <code>new stdClass()</code>
+      <code>new stdClass()</code>
+      <code>new stdClass()</code>
+      <code>new stdClass()</code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
@@ -1082,12 +986,6 @@
       <code>vfsStream::setup()</code>
       <code>vfsStream::setup()</code>
     </DeprecatedClass>
-    <MissingParamType occurrences="1">
-      <code>$arguments</code>
-    </MissingParamType>
-    <MixedArgument occurrences="1">
-      <code>$arguments</code>
-    </MixedArgument>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
@@ -1096,6 +994,9 @@
     </UnusedVariable>
   </file>
   <file src="test/DiskFreeTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$c</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>[]</code>
     </InvalidArgument>
@@ -1105,42 +1006,6 @@
       <code>$freeRightNow + 1073741824</code>
       <code>100</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="9">
-      <code>$a</code>
-      <code>$a</code>
-      <code>$b</code>
-      <code>$b</code>
-      <code>$bytes</code>
-      <code>$c</code>
-      <code>$c</code>
-      <code>$precision</code>
-      <code>$string</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>getTempDir</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="16">
-      <code>$a</code>
-      <code>$a</code>
-      <code>$b</code>
-      <code>$b</code>
-      <code>$bytes</code>
-      <code>$c</code>
-      <code>$precision</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$tmp</code>
-      <code>$tmp</code>
-    </MixedAssignment>
     <MixedInferredReturnType occurrences="3">
       <code>array</code>
       <code>array</code>
@@ -1148,30 +1013,14 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/DiskUsageTest.php">
-    <InvalidScalarArgument occurrences="4">
+    <InvalidScalarArgument occurrences="6">
+      <code>$criticalThreshold</code>
       <code>$dp + 1</code>
       <code>$dp + 2</code>
       <code>$dp - 1</code>
       <code>$dp - 1</code>
+      <code>$warningThreshold</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="3">
-      <code>$criticalThreshold</code>
-      <code>$path</code>
-      <code>$warningThreshold</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>getTempDir</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="8">
-      <code>$criticalThreshold</code>
-      <code>$path</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$this-&gt;getTempDir()</code>
-      <code>$warningThreshold</code>
-    </MixedArgument>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
@@ -1182,7 +1031,7 @@
       <code>$expectedResult</code>
     </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
-      <code>new \stdClass()</code>
+      <code>new stdClass()</code>
     </InvalidArgument>
     <MixedArgument occurrences="2">
       <code>$version</code>
@@ -1193,99 +1042,41 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/GuzzleHttpServiceTest.php">
-    <DeprecatedFunction occurrences="1">
-      <code>parse_response(sprintf($this-&gt;responseTemplate, $statusCode, (string) $content))</code>
-    </DeprecatedFunction>
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$resultClass</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>'not guzzle'</code>
     </InvalidArgument>
     <InvalidScalarArgument occurrences="1">
       <code>'200'</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="10">
-      <code>$actualContent</code>
-      <code>$actualStatusCode</code>
-      <code>$body</code>
-      <code>$content</code>
-      <code>$content</code>
-      <code>$content</code>
-      <code>$method</code>
-      <code>$resultClass</code>
-      <code>$statusCode</code>
-      <code>$statusCode</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$responseTemplate</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>getMockGuzzleClient</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="7">
-      <code>$content</code>
-      <code>$method</code>
-      <code>$resultClass</code>
-      <code>$statusCode</code>
-      <code>$this-&gt;getMockGuzzleClient($actualStatusCode, $actualContent)</code>
-      <code>$this-&gt;responseTemplate</code>
-      <code>GuzzleRequestInterface::class</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$request</code>
-      <code>$response</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
-      <code>attach</code>
+    <MixedMethodCall occurrences="2">
       <code>getBody</code>
       <code>getHeader</code>
     </MixedMethodCall>
-    <TooManyArguments occurrences="1">
-      <code>append</code>
-    </TooManyArguments>
-    <UndefinedClass occurrences="4">
-      <code>Guzzle5MockSubscriber</code>
-      <code>GuzzleRequestInterface</code>
-      <code>GuzzleResponse</code>
-      <code>Stream</code>
-    </UndefinedClass>
-    <UndefinedMagicMethod occurrences="1">
-      <code>getEmitter</code>
-    </UndefinedMagicMethod>
     <UndefinedMethod occurrences="1">
       <code>assertAttributeSame</code>
     </UndefinedMethod>
-    <UnusedParam occurrences="1">
-      <code>$content</code>
-    </UnusedParam>
   </file>
   <file src="test/OpCacheMemoryTest.php">
-    <MissingParamType occurrences="2">
+    <InvalidScalarArgument occurrences="2">
       <code>$criticalThreshold</code>
       <code>$warningThreshold</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>createCheck</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$criticalThreshold</code>
-      <code>$warningThreshold</code>
-    </MixedArgument>
+    </InvalidScalarArgument>
   </file>
   <file src="test/ResultCollectionTest.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>'Iterator'</code>
       <code>'Traversable'</code>
     </ArgumentTypeCoercion>
-    <MissingParamType occurrences="5">
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$value</code>
-    </MissingParamType>
     <MixedArgument occurrences="4">
       <code>$key</code>
       <code>$key</code>
@@ -1314,10 +1105,6 @@
       <code>'foo'</code>
       <code>10</code>
     </InvalidArgument>
-    <MissingParamType occurrences="2">
-      <code>$expectedResult</code>
-      <code>$value</code>
-    </MissingParamType>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
@@ -1337,51 +1124,25 @@
     </UnusedVariable>
   </file>
   <file src="test/TestAsset/Check/ReturnThis.php">
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$value</code>
-    </MissingPropertyType>
-    <MixedInferredReturnType occurrences="1">
-      <code>check</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;value</code>
-    </MixedReturnStatement>
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>mixed</code>
+    </LessSpecificImplementedReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>ReturnThis</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/Check/SecurityAdvisory.php">
-    <MissingReturnType occurrences="1">
-      <code>setAdvisoryAnalyzer</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecurityAdvisory</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/Check/TriggerUserError.php">
-    <MissingParamType occurrences="3">
-      <code>$message</code>
-      <code>$result</code>
-      <code>$severity</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="3">
-      <code>$message</code>
-      <code>$result</code>
-      <code>$severity</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;message</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;severity</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>check</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;result</code>
-    </MixedReturnStatement>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>bool</code>
+    </ImplementedReturnTypeMismatch>
   </file>
   <file src="test/TestAsset/Check/TriggerWarning.php">
     <TooFewArguments occurrences="1">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Check/AbstractCheck.php
+++ b/src/Check/AbstractCheck.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Diagnostics\Check;
 
+use function preg_replace;
+use function strrpos;
+use function substr;
+use function trim;
+
 abstract class AbstractCheck implements CheckInterface
 {
     /**
@@ -22,7 +27,7 @@ abstract class AbstractCheck implements CheckInterface
             return $this->label;
         }
 
-        $class = get_class($this);
+        $class = static::class;
         $class = substr($class, strrpos($class, '\\') + 1);
         $class = preg_replace('/([A-Z])/', ' $1', $class);
 
@@ -33,6 +38,7 @@ abstract class AbstractCheck implements CheckInterface
      * Alias for getLabel()
      *
      * @see CheckInterface::getLabel()
+     *
      * @return string
      */
     public function getName()

--- a/src/Check/AbstractFileCheck.php
+++ b/src/Check/AbstractFileCheck.php
@@ -9,14 +9,20 @@ use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function get_class;
+use function is_array;
+use function is_file;
+use function is_object;
+use function is_readable;
+use function is_string;
+use function sprintf;
+
 /**
  * Abstract class for handling different file checks
  */
 abstract class AbstractFileCheck extends AbstractCheck
 {
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $files;
 
     /**
@@ -48,7 +54,7 @@ abstract class AbstractFileCheck extends AbstractCheck
     public function check()
     {
         foreach ($this->files as $file) {
-            if (! is_file($file) or ! is_readable($file)) {
+            if (! is_file($file) || ! is_readable($file)) {
                 return new Failure(sprintf('File "%s" does not exist or is not readable!', $file));
             }
 

--- a/src/Check/AbstractMemoryCheck.php
+++ b/src/Check/AbstractMemoryCheck.php
@@ -8,6 +8,9 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function is_numeric;
+use function sprintf;
+
 /**
  * Abstract class for handling different memory checks
  */
@@ -58,20 +61,21 @@ abstract class AbstractMemoryCheck extends AbstractCheck implements CheckInterfa
             );
         }
 
-        $this->warningThreshold  = (int)$warningThreshold;
-        $this->criticalThreshold = (int)$criticalThreshold;
+        $this->warningThreshold  = (int) $warningThreshold;
+        $this->criticalThreshold = (int) $criticalThreshold;
     }
 
     /**
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()     *
+     *
      * @return Failure|Skip|Success|Warning
      */
     public function check()
     {
         $percentUsed = ($this->getUsedMemory() / $this->getTotalMemory()) * 100;
-        $message = sprintf(
+        $message     = sprintf(
             '%.0f%% of available %s memory used.',
             $percentUsed,
             $this->formatBytes($this->getTotalMemory())

--- a/src/Check/ApcFragmentation.php
+++ b/src/Check/ApcFragmentation.php
@@ -8,6 +8,14 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function count;
+use function function_exists;
+use function ini_get;
+use function is_numeric;
+use function sprintf;
+
+use const PHP_SAPI;
+
 /**
  * Checks to see if the APCu fragmentation is below warning/critical thresholds
  *
@@ -65,7 +73,7 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
             );
         }
 
-        $this->warningThreshold = (int) $warningThreshold;
+        $this->warningThreshold  = (int) $warningThreshold;
         $this->criticalThreshold = (int) $criticalThreshold;
     }
 
@@ -73,6 +81,7 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Skip|Success|Warning
      */
     public function check()
@@ -81,7 +90,7 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
             return new Skip('APC has not been enabled or installed.');
         }
 
-        if (php_sapi_name() == 'cli' && ! ini_get('apc.enable_cli')) {
+        if (PHP_SAPI === 'cli' && ! ini_get('apc.enable_cli')) {
             return new Skip('APC has not been enabled in CLI.');
         }
 
@@ -98,14 +107,14 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
         for ($i = 0; $i < $info['num_seg']; $i++) {
             $ptr = 0;
             foreach ($info['block_lists'][$i] as $block) {
-                if ($block['offset'] != $ptr) {
+                if ($block['offset'] !== $ptr) {
                     ++$nseg;
                 }
 
                 $ptr = $block['offset'] + $block['size'];
 
                 /* Only consider blocks <5M for the fragmentation % */
-                if ($block['size'] < (5 * 1024 * 1024)) {
+                if ($block['size'] < 5 * 1024 * 1024) {
                     $fragsize += $block['size'];
                 }
 

--- a/src/Check/ApcFragmentation.php
+++ b/src/Check/ApcFragmentation.php
@@ -8,6 +8,7 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function apcu_sma_info;
 use function count;
 use function function_exists;
 use function ini_get;

--- a/src/Check/ApcMemory.php
+++ b/src/Check/ApcMemory.php
@@ -7,6 +7,7 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function apcu_sma_info;
 use function function_exists;
 use function ini_get;
 use function sprintf;

--- a/src/Check/ApcMemory.php
+++ b/src/Check/ApcMemory.php
@@ -7,6 +7,13 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function function_exists;
+use function ini_get;
+use function sprintf;
+
+use const PHP_SAPI;
+use const PHP_VERSION_ID;
+
 /**
  * Checks to see if the APCu memory usage is below warning/critical thresholds
  *
@@ -29,6 +36,7 @@ class ApcMemory extends AbstractMemoryCheck
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()     *
+     *
      * @return Failure|Skip|Success|Warning
      */
     public function check()
@@ -37,7 +45,7 @@ class ApcMemory extends AbstractMemoryCheck
             return new Skip('APC has not been enabled or installed.');
         }
 
-        if (php_sapi_name() == 'cli' && ! ini_get('apc.enable_cli')) {
+        if (PHP_SAPI === 'cli' && ! ini_get('apc.enable_cli')) {
             return new Skip('APC has not been enabled in CLI.');
         }
 

--- a/src/Check/Callback.php
+++ b/src/Check/Callback.php
@@ -4,25 +4,24 @@ namespace Laminas\Diagnostics\Check;
 
 use InvalidArgumentException;
 
+use function call_user_func_array;
+use function is_callable;
+
 /**
  * Run a callback function and return result.
  */
 class Callback extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $callback;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $params = [];
 
     /**
      * @param  callable                  $callback
      * @param  array                     $params
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($callback, $params = [])
     {
@@ -31,13 +30,14 @@ class Callback extends AbstractCheck implements CheckInterface
         }
 
         $this->callback = $callback;
-        $this->params = $params;
+        $this->params   = $params;
     }
 
     /**
      * Perform the Check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return mixed
      */
     public function check()

--- a/src/Check/ClassExists.php
+++ b/src/Check/ClassExists.php
@@ -7,6 +7,15 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function class_exists;
+use function count;
+use function current;
+use function get_class;
+use function implode;
+use function is_array;
+use function is_object;
+use function is_string;
+
 /**
  * Validate that a class or a collection of classes is available.
  */
@@ -56,6 +65,7 @@ class ClassExists extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Success|Failure
      */
     public function check()
@@ -68,8 +78,8 @@ class ClassExists extends AbstractCheck implements CheckInterface
         }
 
         if (count($missing) > 1) {
-            return new Failure('The following classes are missing: ' . join(', ', $missing), $missing);
-        } elseif (count($missing) == 1) {
+            return new Failure('The following classes are missing: ' . implode(', ', $missing), $missing);
+        } elseif (count($missing) === 1) {
             return new Failure('Class ' . current($missing) . ' does not exist', $missing);
         } else {
             return new Success('All classes are present.', $this->classes);

--- a/src/Check/CouchDBCheck.php
+++ b/src/Check/CouchDBCheck.php
@@ -4,6 +4,10 @@ namespace Laminas\Diagnostics\Check;
 
 use Laminas\Diagnostics\Result;
 
+use function array_key_exists;
+use function preg_replace;
+use function sprintf;
+
 /**
  * Ensures a connection to CouchDB is possible.
  */
@@ -13,8 +17,6 @@ class CouchDBCheck extends GuzzleHttpService
      * @param array $couchDbSettings
      * @param array $headers    An array of headers used to create the request
      * @param array $options    An array of guzzle options used to create the request
-     *
-     * @return self
      */
     public function __construct(array $couchDbSettings, array $headers = [], array $options = [])
     {
@@ -40,9 +42,7 @@ class CouchDBCheck extends GuzzleHttpService
         $msg = $result->getMessage();
         $msg = preg_replace('=\/\/(.+):{1}(.+)(\@){1}=i', '//', $msg);
 
-        $failure = new Result\Failure($msg, $result->getData());
-
-        return $failure;
+        return new Result\Failure($msg, $result->getData());
     }
 
     /**
@@ -59,7 +59,6 @@ class CouchDBCheck extends GuzzleHttpService
      *  - password (optional)
      *
      * @param array $couchDbSettings
-     *
      * @return string
      */
     private function createUrlFromParameters(array $couchDbSettings)

--- a/src/Check/CpuPerformance.php
+++ b/src/Check/CpuPerformance.php
@@ -7,6 +7,18 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function bcadd;
+use function bcdiv;
+use function bcmul;
+use function bcpow;
+use function bcscale;
+use function bcsqrt;
+use function bcsub;
+use function ceil;
+use function extension_loaded;
+use function log;
+use function microtime;
+
 /**
  * Calculate CPU Performance by performing a Gauss-Legendre decimal expansion of PI.
  *
@@ -46,7 +58,6 @@ class CpuPerformance extends AbstractCheck implements CheckInterface
     // @codingStandardsIgnoreEnd
 
     /**
-     *
      * @param float $minPerformance The minimum performance ratio, where 1 is equal the computational
      *                              performance of AWS EC2 Micro Instance. For example, a value of 2 means
      *                              at least double the baseline experience, value of 0.5 means at least
@@ -78,12 +89,12 @@ class CpuPerformance extends AbstractCheck implements CheckInterface
         }
         // @codeCoverageIgnoreEnd
 
-        $timeStart = microtime(true);
-        $result = static::calcPi(1000);
-        $duration = microtime(true) - $timeStart;
+        $timeStart   = microtime(true);
+        $result      = static::calcPi(1000);
+        $duration    = microtime(true) - $timeStart;
         $performance = $duration / $this->baseline;
 
-        if ($result != $this->expectedResult) {
+        if ($result !== $this->expectedResult) {
             // Ignore code coverage here because it's impractical to test against faulty calculations.
             // @codeCoverageIgnoreStart
             return new Warning('PI calculation failed. This might mean CPU or RAM failure', $result);
@@ -100,7 +111,8 @@ class CpuPerformance extends AbstractCheck implements CheckInterface
      *
      * @link https://github.com/natmchugh/pi/blob/master/gauss-legendre.php
      * @link http://en.wikipedia.org/wiki/Calculate_pi#Modern_algorithms
-     * @param $precision
+     *
+     * @param int $precision
      * @return string
      */
     public static function calcPi($precision)

--- a/src/Check/DirReadable.php
+++ b/src/Check/DirReadable.php
@@ -7,14 +7,23 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function count;
+use function current;
+use function get_class;
+use function implode;
+use function is_array;
+use function is_dir;
+use function is_object;
+use function is_readable;
+use function is_string;
+use function trim;
+
 /**
  * Validate that a given path (or a collection of paths) is a dir and is readable
  */
 class DirReadable extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $dir;
 
     /**
@@ -44,6 +53,7 @@ class DirReadable extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success
      */
     public function check()
@@ -64,14 +74,14 @@ class DirReadable extends AbstractCheck implements CheckInterface
         // Construct failure message
         $failureString = '';
         if (count($nonDirs) > 1) {
-            $failureString .= 'The following paths are not valid directories: ' . join(', ', $nonDirs) . ' ';
-        } elseif (count($nonDirs) == 1) {
+            $failureString .= 'The following paths are not valid directories: ' . implode(', ', $nonDirs) . ' ';
+        } elseif (count($nonDirs) === 1) {
             $failureString .= current($nonDirs) . ' is not a valid directory. ';
         }
 
         if (count($unreadable) > 1) {
-            $failureString .= 'The following directories are not readable: ' . join(', ', $unreadable);
-        } elseif (count($unreadable) == 1) {
+            $failureString .= 'The following directories are not readable: ' . implode(', ', $unreadable);
+        } elseif (count($unreadable) === 1) {
             $failureString .= current($unreadable) . ' directory is not readable.';
         }
 

--- a/src/Check/DirWritable.php
+++ b/src/Check/DirWritable.php
@@ -7,14 +7,24 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function count;
+use function current;
+use function get_class;
+use function implode;
+use function is_array;
+use function is_dir;
+use function is_object;
+use function is_string;
+use function is_writable;
+use function sprintf;
+use function trim;
+
 /**
  * Validate that a given path (or a collection of paths) is a dir and is writable
  */
 class DirWritable extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $dir;
 
     /**
@@ -44,6 +54,7 @@ class DirWritable extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success
      */
     public function check()
@@ -64,14 +75,14 @@ class DirWritable extends AbstractCheck implements CheckInterface
         // Construct failure message
         $failureString = '';
         if (count($nonDirs) > 1) {
-            $failureString .= sprintf('The following paths are not valid directories: %s. ', join(', ', $nonDirs));
-        } elseif (count($nonDirs) == 1) {
+            $failureString .= sprintf('The following paths are not valid directories: %s. ', implode(', ', $nonDirs));
+        } elseif (count($nonDirs) === 1) {
             $failureString .= sprintf('%s is not a valid directory. ', current($nonDirs));
         }
 
         if (count($unwritable) > 1) {
-            $failureString .= sprintf('The following directories are not writable: %s. ', join(', ', $unwritable));
-        } elseif (count($unwritable) == 1) {
+            $failureString .= sprintf('The following directories are not writable: %s. ', implode(', ', $unwritable));
+        } elseif (count($unwritable) === 1) {
             $failureString .= sprintf('%s directory is not writable. ', current($unwritable));
         }
 

--- a/src/Check/DiskFree.php
+++ b/src/Check/DiskFree.php
@@ -7,6 +7,22 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function array_merge;
+use function array_search;
+use function array_unique;
+use function disk_free_space;
+use function implode;
+use function in_array;
+use function is_float;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+use function preg_match;
+use function round;
+use function sprintf;
+use function strtolower;
+use function substr;
+
 /**
  * Check if there is enough remaining free disk space.
  *
@@ -45,14 +61,14 @@ class DiskFree extends AbstractCheck implements CheckInterface
      * @var  array
      */
     public static $siMultiplier = [
-        0 => 1e0, # 10^0  == 1000^0 (2^00 == 1024^0)
-        1 => 1e3, # 10^3  == 1000^1 (2^10 == 1024^1)
-        2 => 1e6, # 10^6  == 1000^2 (2^20 == 1024^2)
-        3 => 1e9, # 10^9  == 1000^3 (2^30 == 1024^3)
-        4 => 1e12, # 10^12 == 1000^4 (2^40 == 1024^4)
-        5 => 1e15, # 10^15 == 1000^5 (2^50 == 1024^5)
-        6 => 1e18, # 10^18 == 1000^6 (2^60 == 1024^6)
-        7 => 1e21 # 10^21 == 1000^7 (2^70 == 1024^7)
+        0 => 1e0, // 10^0  == 1000^0 (2^00 == 1024^0)
+        1 => 1e3, // 10^3  == 1000^1 (2^10 == 1024^1)
+        2 => 1e6, // 10^6  == 1000^2 (2^20 == 1024^2)
+        3 => 1e9, // 10^9  == 1000^3 (2^30 == 1024^3)
+        4 => 1e12, // 10^12 == 1000^4 (2^40 == 1024^4)
+        5 => 1e15, // 10^15 == 1000^5 (2^50 == 1024^5)
+        6 => 1e18, // 10^18 == 1000^6 (2^60 == 1024^6)
+        7 => 1e21, // 10^21 == 1000^7 (2^70 == 1024^7)
     ];
 
     /**
@@ -75,13 +91,13 @@ class DiskFree extends AbstractCheck implements CheckInterface
      * @var  array
      */
     public static $iecMultiplier = [
-        0 => 1, # 2^00 == 1024^0
-        1 => 1024, # 2^10 == 1024^1
-        2 => 1048576, # 2^20 == 1024^2
-        3 => 1073741824, # 2^30 == 1024^3
-        4 => 1099511627776, # 2^40 == 1024^4
-        5 => 1125899906842624, # 2^50 == 1024^5
-        6 => 1152921504606846976 # 2^60 == 1024^6
+        0 => 1, // 2^00 == 1024^0
+        1 => 1024, // 2^10 == 1024^1
+        2 => 1048576, // 2^20 == 1024^2
+        3 => 1073741824, // 2^30 == 1024^3
+        4 => 1099511627776, // 2^40 == 1024^4
+        5 => 1125899906842624, // 2^50 == 1024^5
+        6 => 1152921504606846976, // 2^60 == 1024^6
     ];
 
     /**
@@ -104,16 +120,16 @@ class DiskFree extends AbstractCheck implements CheckInterface
      * @var  array
      */
     public static $jedecMultiplier = [
-        0 => 1, # 2^00 == 1024^0
-        1 => 1024, # 2^10 == 1024^1
-        2 => 1048576, # 2^20 == 1024^2
-        3 => 1073741824 # 2^30 == 1024^3
+        0 => 1, // 2^00 == 1024^0
+        1 => 1024, // 2^10 == 1024^1
+        2 => 1048576, // 2^20 == 1024^2
+        3 => 1073741824, // 2^30 == 1024^3
     ];
 
     /**
      * @param  int|string                $size Minimum disk size in bytes or a valid byte string (IEC, SI or Jedec).
      * @param  string                    $path The disk path to check, i.e. '/tmp' or 'C:' (defaults to /)
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($size, $path = '/')
     {
@@ -142,6 +158,7 @@ class DiskFree extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success|Warning
      */
     public function check()
@@ -157,7 +174,7 @@ class DiskFree extends AbstractCheck implements CheckInterface
         }
 
         $freeHumanReadable = static::bytesToString($free, 2);
-        $description = sprintf('Remaining space at %s: %s', $this->path, $freeHumanReadable);
+        $description       = sprintf('Remaining space at %s: %s', $this->path, $freeHumanReadable);
 
         if (disk_free_space($this->path) < $this->minDiskBytes) {
             return new Failure($description, $free);
@@ -178,19 +195,19 @@ class DiskFree extends AbstractCheck implements CheckInterface
     public static function bytesToString($size, $precision = 0)
     {
         if ($size >= 1125899906842624) {
-            $size /= 1125899906842624;
+            $size  /= 1125899906842624;
             $suffix = 'PiB';
         } elseif ($size >= 1099511627776) {
-            $size /= 1099511627776;
+            $size  /= 1099511627776;
             $suffix = 'TiB';
         } elseif ($size >= 1073741824) {
-            $size /= 1073741824;
+            $size  /= 1073741824;
             $suffix = 'GiB';
         } elseif ($size >= 1048576) {
-            $size /= 1048576;
+            $size  /= 1048576;
             $suffix = 'MiB';
         } elseif ($size >= 1024) {
-            $size /= 1024;
+            $size  /= 1024;
             $suffix = 'KiB';
         } else {
             $suffix = 'B';
@@ -213,7 +230,7 @@ class DiskFree extends AbstractCheck implements CheckInterface
     {
         // Prepare regular expression.
         $symbol = '(?:([kKMGTPEZ])(i)?)?([Bb])?(?:ps)?';
-        $name = '(' . implode('|', array_unique(array_merge(
+        $name   = '(' . implode('|', array_unique(array_merge(
             self::$siPrefixName,
             self::$iecPrefixName,
             self::$jedecPrefixName
@@ -231,29 +248,29 @@ class DiskFree extends AbstractCheck implements CheckInterface
             if (isset($match[5]) && $match[5]) {
                 $k = strtolower($match[5]);
                 if (in_array($k, self::$iecPrefixName)) {
-                    $a =& self::$iecPrefixName;
-                    $x =& self::$iecMultiplier;
+                    $a = &self::$iecPrefixName;
+                    $x = &self::$iecMultiplier;
                 } elseif (in_array($k, self::$jedecPrefixName) && $jedec) {
-                    $a =& self::$jedecPrefixName;
-                    $x =& self::$jedecMultiplier;
+                    $a = &self::$jedecPrefixName;
+                    $x = &self::$jedecMultiplier;
                 } elseif (in_array($k, self::$siPrefixName)) {
-                    $a =& self::$siPrefixName;
-                    $x =& self::$siMultiplier;
+                    $a = &self::$siPrefixName;
+                    $x = &self::$siMultiplier;
                 }
             }
             // Check for prefix (by symbol).
             if (isset($match[2]) && $match[2]) {
                 $k = $match[2];
-                if (isset($match[3]) && $match[3] == 'i') {
-                    $a =& self::$iecPrefixSymbol;
-                    $x =& self::$iecMultiplier;
+                if (isset($match[3]) && $match[3] === 'i') {
+                    $a  = &self::$iecPrefixSymbol;
+                    $x  = &self::$iecMultiplier;
                     $k .= $match[3];
                 } elseif ($jedec) {
-                    $a =& self::$jedecPrefixSymbol;
-                    $x =& self::$jedecMultiplier;
+                    $a = &self::$jedecPrefixSymbol;
+                    $x = &self::$jedecMultiplier;
                 } else {
-                    $a =& self::$siPrefixSymbol;
-                    $x =& self::$siMultiplier;
+                    $a = &self::$siPrefixSymbol;
+                    $x = &self::$siMultiplier;
                 }
             }
             // Find the correct multiplier and apply it.
@@ -269,8 +286,9 @@ class DiskFree extends AbstractCheck implements CheckInterface
         }
 
         // Check whether we were provided with bits or bytes - divide if needed.
-        if (isset($match[4]) && $match[4] == 'b' ||
-            isset($match[6]) && substr(strtolower($match[6]), 0, 3) == 'bit'
+        if (
+            isset($match[4]) && $match[4] === 'b' ||
+            isset($match[6]) && substr(strtolower($match[6]), 0, 3) === 'bit'
         ) {
             $bytes /= 8;
         }

--- a/src/Check/DiskUsage.php
+++ b/src/Check/DiskUsage.php
@@ -7,6 +7,12 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function disk_free_space;
+use function disk_total_space;
+use function is_numeric;
+use function is_string;
+use function sprintf;
+
 /**
  * Checks to see if the disk usage is below warning/critical percent thresholds
  */
@@ -71,9 +77,9 @@ class DiskUsage extends AbstractCheck implements CheckInterface
             );
         }
 
-        $this->warningThreshold = (int) $warningThreshold;
+        $this->warningThreshold  = (int) $warningThreshold;
         $this->criticalThreshold = (int) $criticalThreshold;
-        $this->path = $path;
+        $this->path              = $path;
     }
 
     /**

--- a/src/Check/DoctrineMigration.php
+++ b/src/Check/DoctrineMigration.php
@@ -11,7 +11,9 @@ use InvalidArgumentException;
 use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
-use LogicException;
+
+use function array_diff;
+use function array_map;
 
 class DoctrineMigration extends AbstractCheck
 {
@@ -26,9 +28,9 @@ class DoctrineMigration extends AbstractCheck
 
     /**
      * @param DependencyFactory|Configuration $input
-     *
-     * @throws InvalidArgumentException if an invalid $input is given - note that this exception will
-     *                                  be removed once PHP 8 union types are introduced here.
+     * @throws InvalidArgumentException If an invalid $input is given - note
+     *     that this exception will be removed once PHP 8 union types are
+     *     introduced here.
      */
     public function __construct($input)
     {
@@ -52,7 +54,7 @@ class DoctrineMigration extends AbstractCheck
     public function check(): ResultInterface
     {
         $availableVersions = $this->getAvailableVersions();
-        $migratedVersions = $this->getMigratedVersions();
+        $migratedVersions  = $this->getMigratedVersions();
 
         $notMigratedVersions = array_diff($availableVersions, $migratedVersions);
         if (! empty($notMigratedVersions)) {

--- a/src/Check/ExtensionLoaded.php
+++ b/src/Check/ExtensionLoaded.php
@@ -7,21 +7,29 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function count;
+use function extension_loaded;
+use function get_class;
+use function implode;
+use function is_array;
+use function is_object;
+use function is_string;
+use function phpversion;
+
 /**
  * Validate that a named extension or a collection of extensions is available.
  */
 class ExtensionLoaded extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $extensions;
 
+    /** @var bool */
     protected $autoload = true;
 
     /**
      * @param  string|array|Traversable  $extensionName PHP extension name or an array of names
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($extensionName)
     {
@@ -46,6 +54,7 @@ class ExtensionLoaded extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success
      */
     public function check()
@@ -58,9 +67,9 @@ class ExtensionLoaded extends AbstractCheck implements CheckInterface
         }
         if (count($missing)) {
             if (count($missing) > 1) {
-                return new Failure('Extensions ' . join(', ', $missing) . ' are not available.');
+                return new Failure('Extensions ' . implode(', ', $missing) . ' are not available.');
             } else {
-                return new Failure('Extension ' . join('', $missing) . ' is not available.');
+                return new Failure('Extension ' . implode('', $missing) . ' is not available.');
             }
         } else {
             if (count($this->extensions) > 1) {
@@ -70,7 +79,7 @@ class ExtensionLoaded extends AbstractCheck implements CheckInterface
                 }
 
                 return new Success(
-                    join(',', $this->extensions) . ' extensions are loaded.',
+                    implode(',', $this->extensions) . ' extensions are loaded.',
                     $versions
                 );
             } else {

--- a/src/Check/HttpService.php
+++ b/src/Check/HttpService.php
@@ -3,36 +3,36 @@
 namespace Laminas\Diagnostics\Check;
 
 use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
+
+use function fclose;
+use function feof;
+use function fgets;
+use function fsockopen;
+use function fwrite;
+use function preg_match;
+use function sprintf;
+use function strpos;
 
 /**
  * Attempt connection to given HTTP host and (optionally) check status code and page content.
  */
 class HttpService extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $port;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $path;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $statusCode;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $content;
 
     /**
@@ -44,15 +44,17 @@ class HttpService extends AbstractCheck
      */
     public function __construct($host, $port = 80, $path = '/', $statusCode = null, $content = null)
     {
-        $this->host = $host;
-        $this->port = $port;
-        $this->path = $path;
+        $this->host       = $host;
+        $this->port       = $port;
+        $this->path       = $path;
         $this->statusCode = $statusCode;
-        $this->content = $content;
+        $this->content    = $content;
     }
 
     /**
      * @see Laminas\Diagnostics\CheckInterface::check()
+     *
+     * @return ResultInterface
      */
     public function check()
     {
@@ -65,10 +67,10 @@ class HttpService extends AbstractCheck
             ));
         }
 
-        $header = "GET {$this->path} HTTP/1.0\r\n";
+        $header  = "GET {$this->path} HTTP/1.0\r\n";
         $header .= "Host: {$this->host}\r\n";
         $header .= "Connection: close\r\n\r\n";
-        fputs($fp, $header);
+        fwrite($fp, $header);
         $str = '';
         while (! feof($fp)) {
             $str .= fgets($fp, 1024);

--- a/src/Check/IniFile.php
+++ b/src/Check/IniFile.php
@@ -6,6 +6,11 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 
+use function count;
+use function is_array;
+use function parse_ini_file;
+use function sprintf;
+
 /**
  * Checks if an INI file is available and valid
  */
@@ -17,7 +22,7 @@ class IniFile extends AbstractFileCheck
      */
     protected function validateFile($file)
     {
-        if (! is_array($ini = parse_ini_file($file)) or count($ini) < 1) {
+        if (! is_array($ini = parse_ini_file($file)) || count($ini) < 1) {
             return new Failure(sprintf('Could not parse INI file "%s"!', $file));
         }
 

--- a/src/Check/JsonFile.php
+++ b/src/Check/JsonFile.php
@@ -6,6 +6,10 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 
+use function file_get_contents;
+use function json_decode;
+use function sprintf;
+
 /**
  * Checks if a JSON file is available and valid
  */
@@ -17,7 +21,7 @@ class JsonFile extends AbstractFileCheck
      */
     protected function validateFile($file)
     {
-        if (is_null(json_decode(file_get_contents($file)))) {
+        if (null === json_decode(file_get_contents($file))) {
             return new Failure(sprintf('Could no decode JSON file "%s"', $file));
         }
 

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -5,22 +5,25 @@ namespace Laminas\Diagnostics\Check;
 use Exception;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 use Memcache as MemcacheService;
+
+use function class_exists;
+use function gettype;
+use function is_array;
+use function is_string;
+use function sprintf;
 
 /**
  * Check if MemCache extension is loaded and given server is reachable.
  */
 class Memcache extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $port;
 
     /**
@@ -51,6 +54,8 @@ class Memcache extends AbstractCheck
 
     /**
      * @see CheckInterface::check()
+     *
+     * @return ResultInterface
      */
     public function check()
     {
@@ -65,7 +70,8 @@ class Memcache extends AbstractCheck
 
             $authority = sprintf('%s:%d', $this->host, $this->port);
 
-            if (! $stats
+            if (
+                ! $stats
                 || ! is_array($stats)
                 || ! isset($stats[$authority])
                 || false === $stats[$authority]

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -5,29 +5,32 @@ namespace Laminas\Diagnostics\Check;
 use Exception;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 use Memcached as MemcachedService;
+
+use function class_exists;
+use function gettype;
+use function is_array;
+use function is_string;
+use function sprintf;
 
 /**
  * Check if MemCached extension is loaded and given server is reachable.
  */
 class Memcached extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $port;
 
     /**
      * @param string $host
      * @param int    $port
-     * @throws InvalidArgumentException if host is not a string value
-     * @throws InvalidArgumentException if port is less than 1
+     * @throws InvalidArgumentException If host is not a string value.
+     * @throws InvalidArgumentException If port is less than 1.
      */
     public function __construct($host = '127.0.0.1', $port = 11211)
     {
@@ -52,6 +55,8 @@ class Memcached extends AbstractCheck
 
     /**
      * @see CheckInterface::check()
+     *
+     * @return ResultInterface
      */
     public function check()
     {
@@ -66,7 +71,8 @@ class Memcached extends AbstractCheck
 
             $authority = sprintf('%s:%d', $this->host, $this->port);
 
-            if (! $stats
+            if (
+                ! $stats
                 || ! is_array($stats)
                 || ! isset($stats[$authority])
                 || false === $stats[$authority]

--- a/src/Check/Mongo.php
+++ b/src/Check/Mongo.php
@@ -3,17 +3,20 @@
 namespace Laminas\Diagnostics\Check;
 
 use Exception;
+use Iterator;
 use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use MongoClient;
+use MongoConnectionException;
 use MongoDB\Client as MongoDBClient;
 use RuntimeException;
 
+use function class_exists;
+use function sprintf;
+
 class Mongo extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $connectionUri;
 
     /**
@@ -42,11 +45,10 @@ class Mongo extends AbstractCheck
     }
 
     /**
-     * @return array|\Iterator
-     *
-     * @throws \RuntimeException
+     * @return array|Iterator
+     * @throws RuntimeException
      * @throws \MongoDB\Driver\Exception
-     * @throws \MongoConnectionException
+     * @throws MongoConnectionException
      */
     private function getListDBs()
     {

--- a/src/Check/OpCacheMemory.php
+++ b/src/Check/OpCacheMemory.php
@@ -7,6 +7,11 @@ use Laminas\Diagnostics\Result\Skip;
 use Laminas\Diagnostics\Result\Success;
 use Laminas\Diagnostics\Result\Warning;
 
+use function array_key_exists;
+use function function_exists;
+use function is_array;
+use function opcache_get_status;
+
 /**
  * Checks to see if the OpCache memory usage is below warning/critical thresholds
  */
@@ -23,6 +28,7 @@ class OpCacheMemory extends AbstractMemoryCheck
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()     *
+     *
      * @return Failure|Skip|Success|Warning
      */
     public function check()

--- a/src/Check/PDOCheck.php
+++ b/src/Check/PDOCheck.php
@@ -4,15 +4,25 @@ namespace Laminas\Diagnostics\Check;
 
 use Laminas\Diagnostics\Result;
 use PDO;
+use PDOException;
+
+use function sprintf;
 
 /**
  * Ensures a connection to the MySQL server/database is possible.
  */
 class PDOCheck implements CheckInterface
 {
+    /** @var string */
     private $dsn;
+
+    /** @var string */
     private $password;
+
+    /** @var string */
     private $username;
+
+    /** @var int */
     private $timeout;
 
     /**
@@ -20,15 +30,13 @@ class PDOCheck implements CheckInterface
      * @param string $username
      * @param string $password
      * @param int $timeout
-     *
-     * @return self
      */
     public function __construct($dsn, $username, $password, $timeout = 1)
     {
-        $this->dsn = $dsn;
+        $this->dsn      = $dsn;
         $this->username = $username;
         $this->password = $password;
-        $this->timeout = $timeout;
+        $this->timeout  = $timeout;
     }
 
     /**
@@ -41,7 +49,7 @@ class PDOCheck implements CheckInterface
         try {
             $options = [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_TIMEOUT => $this->timeout
+                PDO::ATTR_TIMEOUT => $this->timeout,
             ];
 
             $pdo = new PDO($this->dsn, $this->username, $this->password, $options);
@@ -50,7 +58,7 @@ class PDOCheck implements CheckInterface
             if (null !== $status) {
                 return new Result\Success('Connection to database server was successful.');
             }
-        } catch (\PDOException $e) {
+        } catch (PDOException $e) {
             // skip to failure
             $msg .= ', e: ' . $e->getCode();
         }

--- a/src/Check/PhpFlag.php
+++ b/src/Check/PhpFlag.php
@@ -7,6 +7,16 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function count;
+use function get_class;
+use function gettype;
+use function implode;
+use function ini_get;
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function iterator_to_array;
+
 /**
  * Make sure given PHP flag is turned on or off in php.ini
  *
@@ -14,18 +24,14 @@ use Traversable;
  */
 class PhpFlag extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $settings;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $expectedValue;
 
     /**
-     * @param string|array|traversable $settingName   PHP setting names to check.
+     * @param string|array|Traversable $settingName   PHP setting names to check.
      * @param bool                     $expectedValue true or false
      * @throws InvalidArgumentException
      */
@@ -55,13 +61,14 @@ class PhpFlag extends AbstractCheck implements CheckInterface
             );
         }
 
-        $this->expectedValue = (bool)$expectedValue;
+        $this->expectedValue = (bool) $expectedValue;
     }
 
     /**
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Success|Failure
      */
     public function check()
@@ -69,6 +76,7 @@ class PhpFlag extends AbstractCheck implements CheckInterface
         $failures = [];
 
         foreach ($this->settings as $name) {
+            // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator
             if (ini_get($name) != $this->expectedValue) {
                 $failures[] = $name;
             }
@@ -76,29 +84,29 @@ class PhpFlag extends AbstractCheck implements CheckInterface
 
         if (count($failures) > 1) {
             return new Failure(
-                join(', ', $failures) .
-                ' are expected to be ' .
-                ($this->expectedValue ? 'enabled' : 'disabled')
+                implode(', ', $failures)
+                . ' are expected to be '
+                . ($this->expectedValue ? 'enabled' : 'disabled')
             );
         } elseif (count($failures)) {
             return new Failure(
-                $failures[0] .
-                ' is expected to be ' .
-                ($this->expectedValue ? 'enabled' : 'disabled')
+                $failures[0]
+                . ' is expected to be '
+                . ($this->expectedValue ? 'enabled' : 'disabled')
             );
         }
 
         if (count($this->settings) > 1) {
             return new Success(
-                join(', ', $this->settings) .
-                ' are all ' .
-                ($this->expectedValue ? 'enabled' : 'disabled')
+                implode(', ', $this->settings)
+                . ' are all '
+                . ($this->expectedValue ? 'enabled' : 'disabled')
             );
         } else {
             return new Success(
-                $this->settings[0] .
-                ' is ' .
-                ($this->expectedValue ? 'enabled' : 'disabled')
+                $this->settings[0]
+                . ' is '
+                . ($this->expectedValue ? 'enabled' : 'disabled')
             );
         }
     }

--- a/src/Check/PhpVersion.php
+++ b/src/Check/PhpVersion.php
@@ -7,6 +7,17 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function get_class;
+use function gettype;
+use function in_array;
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function sprintf;
+use function version_compare;
+
+use const PHP_VERSION;
+
 /**
  * Validate PHP version.
  *
@@ -15,18 +26,13 @@ use Traversable;
  */
 class PhpVersion extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $version;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $operator = '>=';
 
     /**
-     *
      * @param  string|array|Traversable $expectedVersion The expected version
      * @param  string                   $operator        One of: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
      * @throws InvalidArgumentException
@@ -34,7 +40,7 @@ class PhpVersion extends AbstractCheck implements CheckInterface
     public function __construct($expectedVersion, $operator = '>=')
     {
         if (is_object($expectedVersion)) {
-            if (! $expectedVersion instanceof \Traversable) {
+            if (! $expectedVersion instanceof Traversable) {
                 throw new InvalidArgumentException(
                     'Expected version number as string, array or traversable, got ' . get_class($expectedVersion)
                 );
@@ -58,9 +64,24 @@ class PhpVersion extends AbstractCheck implements CheckInterface
             );
         }
 
-        if (! in_array($operator, [
-            '<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'
-        ])) {
+        if (
+            ! in_array($operator, [
+                '<',
+                'lt',
+                '<=',
+                'le',
+                '>',
+                'gt',
+                '>=',
+                'ge',
+                '==',
+                '=',
+                'eq',
+                '!=',
+                '<>',
+                'ne',
+            ])
+        ) {
             throw new InvalidArgumentException(
                 'Unknown comparison operator ' . $operator
             );
@@ -73,6 +94,7 @@ class PhpVersion extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Success|Failure
      */
     public function check()

--- a/src/Check/ProcessRunning.php
+++ b/src/Check/ProcessRunning.php
@@ -4,41 +4,45 @@ namespace Laminas\Diagnostics\Check;
 
 use InvalidArgumentException;
 use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
+
+use function escapeshellarg;
+use function exec;
+use function gettype;
+use function is_numeric;
+use function is_scalar;
+use function sprintf;
 
 /**
  * Check if a process with given name or ID is currently running.
  */
 class ProcessRunning extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $processName;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $pid;
 
     /**
      * @param string|int $processNameOrPid   Name or ID of the process to find.
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($processNameOrPid)
     {
         if (empty($processNameOrPid)) {
             throw new InvalidArgumentException(sprintf(
-                'Wrong argument provided for ProcessRunning check - ' .
-                'expected a process name (string) or pid (positive number).',
+                'Wrong argument provided for ProcessRunning check - '
+                . 'expected a process name (string) or pid (positive number).',
                 gettype($processNameOrPid)
             ));
         }
 
         if (! is_numeric($processNameOrPid) && ! is_scalar($processNameOrPid)) {
             throw new InvalidArgumentException(sprintf(
-                'Wrong argument provided for ProcessRunning check - ' .
-                'expected a process name (string) or pid (positive number) but got %s',
+                'Wrong argument provided for ProcessRunning check - '
+                . 'expected a process name (string) or pid (positive number) but got %s',
                 gettype($processNameOrPid)
             ));
         }
@@ -46,8 +50,8 @@ class ProcessRunning extends AbstractCheck
         if (is_numeric($processNameOrPid)) {
             if ((int) $processNameOrPid < 0) {
                 throw new InvalidArgumentException(sprintf(
-                    'Wrong argument provided for ProcessRunning check - ' .
-                    'expected pid to be a positive number but got %s',
+                    'Wrong argument provided for ProcessRunning check - '
+                    . 'expected pid to be a positive number but got %s',
                     (int) $processNameOrPid
                 ));
             }
@@ -59,6 +63,8 @@ class ProcessRunning extends AbstractCheck
 
     /**
      * @see Laminas\Diagnostics\CheckInterface::check()
+     *
+     * @return ResultInterface
      */
     public function check()
     {
@@ -71,13 +77,13 @@ class ProcessRunning extends AbstractCheck
     }
 
     /**
-     * @return \Laminas\Diagnostics\Result\ResultInterface
+     * @return ResultInterface
      */
     private function checkAgainstPid()
     {
         exec('ps -p ' . (int) $this->pid, $output, $return);
 
-        if ($return == 1) {
+        if ($return === 1) {
             return new Failure(sprintf('Process with PID %s is not currently running.', $this->pid));
         }
 
@@ -85,7 +91,7 @@ class ProcessRunning extends AbstractCheck
     }
 
     /**
-     * @return \Laminas\Diagnostics\Result\ResultInterface
+     * @return ResultInterface
      */
     private function checkAgainstProcessName()
     {

--- a/src/Check/RabbitMQ.php
+++ b/src/Check/RabbitMQ.php
@@ -2,39 +2,34 @@
 
 namespace Laminas\Diagnostics\Check;
 
+use Exception;
 use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPSocketConnection;
+use RuntimeException;
+
+use function class_exists;
+use function sprintf;
 
 /**
  * Validate that a RabbitMQ service is running
  */
 class RabbitMQ extends AbstractCheck
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var integer
-     */
+    /** @var integer */
     protected $port;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $user;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $password;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $vhost;
 
     /**
@@ -60,8 +55,7 @@ class RabbitMQ extends AbstractCheck
 
     /**
      * @return AMQPSocketConnection|AMQPConnection
-     *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     private function createClient()
     {
@@ -85,13 +79,14 @@ class RabbitMQ extends AbstractCheck
             );
         }
 
-        throw new \RuntimeException('PhpAmqpLib is not installed');
+        throw new RuntimeException('PhpAmqpLib is not installed');
     }
 
     /**
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success
      */
     public function check()
@@ -99,7 +94,7 @@ class RabbitMQ extends AbstractCheck
         try {
             $this->createClient()->channel();
             return new Success();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return new Failure(sprintf(
                 'Failed to connect to RabbitMQ server. Reason: `%s`',
                 $e->getMessage()

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -5,25 +5,23 @@ namespace Laminas\Diagnostics\Check;
 use Laminas\Diagnostics\Result\Success;
 use Predis\Client as PredisClient;
 use Redis as RedisExtensionClient;
+use RedisException;
+use RuntimeException;
+
+use function class_exists;
 
 /**
  * Validate that a Redis service is running
  */
 class Redis extends AbstractCheck
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $auth;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $port;
 
     /**
@@ -42,6 +40,8 @@ class Redis extends AbstractCheck
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
+     * @return Success
      */
     public function check()
     {
@@ -52,9 +52,8 @@ class Redis extends AbstractCheck
 
     /**
      * @return PredisClient|RedisExtensionClient
-     *
-     * @throws \RedisException
-     * @throws \RuntimeException
+     * @throws RedisException
+     * @throws RuntimeException
      */
     private function createClient()
     {
@@ -63,13 +62,13 @@ class Redis extends AbstractCheck
             $client->connect($this->host, $this->port);
 
             if ($this->auth && false === $client->auth($this->auth)) {
-                throw new \RedisException('Failed to AUTH connection');
+                throw new RedisException('Failed to AUTH connection');
             }
 
             return $client;
         }
 
-        if (class_exists('Predis\Client')) {
+        if (class_exists(PredisClient::class)) {
             $parameters = [
                 'host' => $this->host,
                 'port' => $this->port,
@@ -82,6 +81,6 @@ class Redis extends AbstractCheck
             return new PredisClient($parameters);
         }
 
-        throw new \RuntimeException('Neither the PHP Redis extension or Predis are installed');
+        throw new RuntimeException('Neither the PHP Redis extension or Predis are installed');
     }
 }

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -57,7 +57,7 @@ class Redis extends AbstractCheck
      */
     private function createClient()
     {
-        if (class_exists('\Redis')) {
+        if (class_exists(RedisExtensionClient::class)) {
             $client = new RedisExtensionClient();
             $client->connect($this->host, $this->port);
 

--- a/src/Check/StreamWrapperExists.php
+++ b/src/Check/StreamWrapperExists.php
@@ -7,14 +7,25 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;
 use Traversable;
 
+use function array_walk;
+use function count;
+use function current;
+use function get_class;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_object;
+use function is_string;
+use function sprintf;
+use function stream_get_wrappers;
+use function strtolower;
+
 /**
  * Validate that a stream wrapper exists.
  */
 class StreamWrapperExists extends AbstractCheck implements CheckInterface
 {
-    /**
-     * @var array|Traversable
-     */
+    /** @var array|Traversable */
     protected $wrappers;
 
     /**
@@ -48,11 +59,12 @@ class StreamWrapperExists extends AbstractCheck implements CheckInterface
      * Perform the check
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
+     *
      * @return Failure|Success
      */
     public function check()
     {
-        $missingWrappers = [];
+        $missingWrappers   = [];
         $availableWrappers = stream_get_wrappers();
         array_walk($availableWrappers, function ($v) {
             return strtolower($v);
@@ -64,7 +76,7 @@ class StreamWrapperExists extends AbstractCheck implements CheckInterface
             }
         }
 
-        if (count($missingWrappers) == 1) {
+        if (count($missingWrappers) === 1) {
             return new Failure(
                 sprintf('Stream wrapper %s is not available', current($missingWrappers)),
                 $availableWrappers
@@ -75,14 +87,14 @@ class StreamWrapperExists extends AbstractCheck implements CheckInterface
             return new Failure(
                 sprintf(
                     'The following stream wrappers are missing: %s',
-                    join(', ', $missingWrappers)
+                    implode(', ', $missingWrappers)
                 ),
                 $availableWrappers
             );
         }
 
         return new Success(
-            sprintf('%s stream wrapper(s) are available', join(', ', $this->wrappers)),
+            sprintf('%s stream wrapper(s) are available', implode(', ', $this->wrappers)),
             $availableWrappers
         );
     }

--- a/src/Check/XmlFile.php
+++ b/src/Check/XmlFile.php
@@ -7,6 +7,9 @@ use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 use XMLReader;
 
+use function simplexml_load_file;
+use function sprintf;
+
 /**
  * Checks if an XML file is available and valid
  */

--- a/src/Check/YamlFile.php
+++ b/src/Check/YamlFile.php
@@ -12,6 +12,7 @@ use function class_exists;
 use function file_get_contents;
 use function function_exists;
 use function sprintf;
+use function yaml_parse_file;
 
 /**
  * Checks if a YAML file is available and valid

--- a/src/Check/YamlFile.php
+++ b/src/Check/YamlFile.php
@@ -8,6 +8,11 @@ use Laminas\Diagnostics\Result\Success;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 
+use function class_exists;
+use function file_get_contents;
+use function function_exists;
+use function sprintf;
+
 /**
  * Checks if a YAML file is available and valid
  */
@@ -19,7 +24,7 @@ class YamlFile extends AbstractFileCheck
      */
     protected function validateFile($file)
     {
-        if (class_exists('Symfony\Component\Yaml\Parser')) {
+        if (class_exists(Parser::class)) {
             $parser = new Parser();
 
             try {

--- a/src/Result/AbstractResult.php
+++ b/src/Result/AbstractResult.php
@@ -7,14 +7,10 @@ namespace Laminas\Diagnostics\Result;
  */
 abstract class AbstractResult implements ResultInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $message;
 
-    /**
-     * @var mixed|null
-     */
+    /** @var mixed|null */
     protected $data;
 
     /**

--- a/src/Result/Collection.php
+++ b/src/Result/Collection.php
@@ -4,11 +4,18 @@ namespace Laminas\Diagnostics\Result;
 
 use InvalidArgumentException;
 use Laminas\Diagnostics\Check\CheckInterface;
+use ReturnTypeWillChange;
+use SplObjectStorage;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Utility class to store Results entities for corresponding Checks
  */
-class Collection extends \SplObjectStorage
+class Collection extends SplObjectStorage
 {
     /**
      * Number of successful results
@@ -96,11 +103,12 @@ class Collection extends \SplObjectStorage
     }
 
     /**
+     * @link http://php.net/manual/en/splobjectstorage.offsetget.php
+     *
      * @param  object $index
      * @return mixed
-     * @link http://php.net/manual/en/splobjectstorage.offsetget.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($index)
     {
         $this->validateIndex($index);
@@ -109,11 +117,12 @@ class Collection extends \SplObjectStorage
     }
 
     /**
+     * @link http://php.net/manual/en/splobjectstorage.offsetexists.php
+     *
      * @param  object $index
      * @return bool
-     * @link http://php.net/manual/en/splobjectstorage.offsetexists.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($index)
     {
         $this->validateIndex($index);
@@ -122,11 +131,12 @@ class Collection extends \SplObjectStorage
     }
 
     /**
+     * @link http://php.net/manual/en/splobjectstorage.offsetset.php
+     *
      * @param object     $index
      * @param mixed|null $checkResult
-     * @link http://php.net/manual/en/splobjectstorage.offsetset.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $checkResult = null)
     {
         $this->validateIndex($index);
@@ -145,10 +155,11 @@ class Collection extends \SplObjectStorage
     }
 
     /**
-     * @param object $index
      * @link http://php.net/manual/en/splobjectstorage.offsetunset.php
+     *
+     * @param object $index
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($index)
     {
         $this->validateIndex($index);
@@ -164,7 +175,6 @@ class Collection extends \SplObjectStorage
     /**
      * Adjust internal result counters.
      *
-     * @param ResultInterface $result
      * @param int             $delta
      */
     protected function updateCounters(ResultInterface $result, $delta = 1)

--- a/src/Runner/Reporter/BasicConsole.php
+++ b/src/Runner/Reporter/BasicConsole.php
@@ -11,6 +11,18 @@ use Laminas\Diagnostics\Result\SkipInterface;
 use Laminas\Diagnostics\Result\SuccessInterface;
 use Laminas\Diagnostics\Result\WarningInterface;
 
+use function count;
+use function floor;
+use function get_class;
+use function log10;
+use function round;
+use function sprintf;
+use function str_pad;
+
+use const PHP_EOL;
+use const STR_PAD_LEFT;
+use const STR_PAD_RIGHT;
+
 /**
  * A simple reporter for displaying Runner results in console window.
  */
@@ -77,22 +89,22 @@ class BasicConsole implements ReporterInterface
 
     /**
      * @see \Laminas\Diagnostics\Runner\Reporter\ReporterInterface
-     * @param ArrayObject $checks
+     *
      * @param array       $runnerConfig
      */
     public function onStart(ArrayObject $checks, $runnerConfig)
     {
-        $this->stopped = false;
+        $this->stopped   = false;
         $this->iteration = 1;
-        $this->pos = 1;
-        $this->total = count($checks);
+        $this->pos       = 1;
+        $this->total     = count($checks);
 
         // Calculate gutter width to accommodate number of tests passed
         if ($this->total <= $this->width) {
             $this->gutter = 0; // everything fits well
         } else {
             $this->countLength = floor(log10($this->total)) + 1;
-            $this->gutter = ($this->countLength * 2) + 11;
+            $this->gutter      = ($this->countLength * 2) + 11;
         }
 
         $this->consoleWriteLn('Starting diagnostics:');
@@ -101,7 +113,7 @@ class BasicConsole implements ReporterInterface
 
     /**
      * @see \Laminas\Diagnostics\Runner\Reporter\ReporterInterface
-     * @param  CheckInterface $check
+     *
      * @param  string|null    $checkAlias
      * @return bool|void
      */
@@ -111,8 +123,7 @@ class BasicConsole implements ReporterInterface
 
     /**
      * @see \Laminas\Diagnostics\Runner\Reporter\ReporterInterface
-     * @param  CheckInterface  $check
-     * @param  ResultInterface $result
+     *
      * @param  string|null     $checkAlias
      * @return bool|void
      */
@@ -157,7 +168,6 @@ class BasicConsole implements ReporterInterface
 
     /**
      * @see \Laminas\Diagnostics\Runner\Reporter\ReporterInterface
-     * @param ResultsCollection $results
      */
     public function onFinish(ResultsCollection $results)
     {
@@ -165,15 +175,16 @@ class BasicConsole implements ReporterInterface
         $this->consoleWriteLn();
 
         // Display a summary line
-        if ($results->getFailureCount() == 0
-            && $results->getWarningCount() == 0
-            && $results->getUnknownCount() == 0
-            && $results->getSkipCount() == 0
+        if (
+            $results->getFailureCount() === 0
+            && $results->getWarningCount() === 0
+            && $results->getUnknownCount() === 0
+            && $results->getSkipCount() === 0
         ) {
             $line = 'OK (' . $this->total . ' diagnostic tests)';
             $this->consoleWrite(str_pad($line, $this->width - 1, ' ', STR_PAD_RIGHT));
-        } elseif ($results->getFailureCount() == 0) {
-            $line = $results->getWarningCount() . ' warnings, ';
+        } elseif ($results->getFailureCount() === 0) {
+            $line  = $results->getWarningCount() . ' warnings, ';
             $line .= $results->getSuccessCount() . ' successful tests';
 
             if ($results->getSkipCount() > 0) {
@@ -188,7 +199,7 @@ class BasicConsole implements ReporterInterface
 
             $this->consoleWrite(str_pad($line, $this->width - 1, ' ', STR_PAD_RIGHT));
         } else {
-            $line = $results->getFailureCount() . ' failures, ';
+            $line  = $results->getFailureCount() . ' failures, ';
             $line .= $results->getWarningCount() . ' warnings, ';
             $line .= $results->getSuccessCount() . ' successful tests';
 
@@ -209,8 +220,6 @@ class BasicConsole implements ReporterInterface
         $this->consoleWriteLn();
         // Display a list of failures and warnings
         foreach ($results as $check) {
-            /* @var $check  \Laminas\Diagnostics\Check\CheckInterface */
-            /* @var $result \Laminas\Diagnostics\Result\ResultInterface */
             $result = $results[$check];
 
             if ($result instanceof FailureInterface) {
@@ -245,7 +254,6 @@ class BasicConsole implements ReporterInterface
 
     /**
      * @see \Laminas\Diagnostics\Runner\Reporter\ReporterInterface
-     * @param ResultsCollection $results
      */
     public function onStop(ResultsCollection $results)
     {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,6 +1,7 @@
 <?php
 
-if (class_exists(Doctrine\DBAL\Migrations\Configuration\Configuration::class)
+if (
+    class_exists(Doctrine\DBAL\Migrations\Configuration\Configuration::class)
     && ! class_exists(Doctrine\Migrations\Configuration\Configuration::class)
 ) {
     class_alias(

--- a/test/AbstractMemoryTest.php
+++ b/test/AbstractMemoryTest.php
@@ -3,15 +3,15 @@
 namespace LaminasTest\Diagnostics;
 
 use InvalidArgumentException;
+use Laminas\Diagnostics\Check\CheckInterface;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @author Kevin Bond <kevinbond@gmail.com>
- */
 abstract class AbstractMemoryTest extends TestCase
 {
     /**
      * @dataProvider invalidArgumentProvider
+     * @param string|int $warningThreshold
+     * @param string|int $criticalThreshold
      */
     public function testInvalidArguments($warningThreshold, $criticalThreshold): void
     {
@@ -28,9 +28,14 @@ abstract class AbstractMemoryTest extends TestCase
             [-10, 100],
             [105, 100],
             [10, -10],
-            [10, 105]
+            [10, 105],
         ];
     }
 
+    /**
+     * @param string|int $warningThreshold
+     * @param string|int $criticalThreshold
+     * @return CheckInterface
+     */
     abstract protected function createCheck($warningThreshold, $criticalThreshold);
 }

--- a/test/ApcFragmentationTest.php
+++ b/test/ApcFragmentationTest.php
@@ -6,13 +6,12 @@ use InvalidArgumentException;
 use Laminas\Diagnostics\Check\ApcFragmentation;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @author Kevin Bond <kevinbond@gmail.com>
- */
 class ApcFragmentationTest extends TestCase
 {
     /**
      * @dataProvider invalidArgumentProvider
+     * @param int|string $warningThreshold
+     * @param int|string $criticalThreshold
      */
     public function testInvalidArguments($warningThreshold, $criticalThreshold): void
     {
@@ -29,7 +28,7 @@ class ApcFragmentationTest extends TestCase
             [-10, 100],
             [105, 100],
             [10, -10],
-            [10, 105]
+            [10, 105],
         ];
     }
 }

--- a/test/ApcMemoryTest.php
+++ b/test/ApcMemoryTest.php
@@ -4,11 +4,13 @@ namespace LaminasTest\Diagnostics;
 
 use Laminas\Diagnostics\Check\ApcMemory;
 
-/**
- * @author Kevin Bond <kevinbond@gmail.com>
- */
 class ApcMemoryTest extends AbstractMemoryTest
 {
+    /**
+     * @param int|string $warningThreshold
+     * @param int|string $criticalThreshold
+     * @return ApcMemory
+     */
     protected function createCheck($warningThreshold, $criticalThreshold)
     {
         return new ApcMemory($warningThreshold, $criticalThreshold);

--- a/test/BasicClassesTest.php
+++ b/test/BasicClassesTest.php
@@ -16,36 +16,46 @@ use LaminasTest\Diagnostics\TestAsset\Check\AlwaysSuccess;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+use function class_exists;
+use function interface_exists;
+use function trim;
+
 class BasicClassesTest extends TestCase
 {
     public function testCoreClassTree(): void
     {
-        foreach ([
-            CheckInterface::class,
-            SuccessInterface::class,
-            FailureInterface::class,
-            WarningInterface::class,
-        ] as $class) {
+        foreach (
+            [
+                CheckInterface::class,
+                SuccessInterface::class,
+                FailureInterface::class,
+                WarningInterface::class,
+            ] as $class
+        ) {
             self::assertTrue(interface_exists($class, true), 'Class "' . $class . '" exists.');
         }
 
-        foreach ([
-            AbstractCheck::class,
-            AbstractResult::class,
-            Success::class,
-            Failure::class,
-            Warning::class,
-        ] as $class) {
+        foreach (
+            [
+                AbstractCheck::class,
+                AbstractResult::class,
+                Success::class,
+                Failure::class,
+                Warning::class,
+            ] as $class
+        ) {
             self::assertTrue(class_exists($class, true), 'Class "' . $class . '" exists.');
         }
-        foreach ([
-            Success::class,
-            Failure::class,
-            Warning::class,
-            SuccessInterface::class,
-            FailureInterface::class,
-            WarningInterface::class,
-        ] as $class) {
+        foreach (
+            [
+                Success::class,
+                Failure::class,
+                Warning::class,
+                SuccessInterface::class,
+                FailureInterface::class,
+                WarningInterface::class,
+            ] as $class
+        ) {
             $reflection = new ReflectionClass($class);
             self::assertTrue($reflection->implementsInterface(ResultInterface::class));
         }

--- a/test/BasicConsoleReporterTest.php
+++ b/test/BasicConsoleReporterTest.php
@@ -12,11 +12,16 @@ use LaminasTest\Diagnostics\TestAsset\Check\AlwaysSuccess;
 use LaminasTest\Diagnostics\TestAsset\Result\Unknown;
 use PHPUnit\Framework\TestCase;
 
+use function array_fill;
+use function ob_clean;
+use function ob_get_clean;
+use function ob_start;
+use function str_repeat;
+use function trim;
+
 class BasicConsoleReporterTest extends TestCase
 {
-    /**
-     * @var BasicConsole
-     */
+    /** @var BasicConsole */
     protected $reporter;
 
     protected function setUp(): void
@@ -99,7 +104,7 @@ class BasicConsoleReporterTest extends TestCase
     public function testProgressDotsNoGutter(): void
     {
         $this->reporter = new BasicConsole(40);
-        $checks = new ArrayObject(array_fill(0, 40, new AlwaysSuccess()));
+        $checks         = new ArrayObject(array_fill(0, 40, new AlwaysSuccess()));
 
         ob_start();
         $this->reporter->onStart($checks, []);
@@ -116,7 +121,7 @@ class BasicConsoleReporterTest extends TestCase
     public function testProgressOverflow(): void
     {
         $this->reporter = new BasicConsole(40);
-        $checks = new ArrayObject(array_fill(0, 80, new AlwaysSuccess()));
+        $checks         = new ArrayObject(array_fill(0, 80, new AlwaysSuccess()));
 
         ob_start();
         $this->reporter->onStart($checks, []);
@@ -138,7 +143,7 @@ class BasicConsoleReporterTest extends TestCase
     public function testProgressOverflowMatch(): void
     {
         $this->reporter = new BasicConsole(40);
-        $checks = new ArrayObject(array_fill(0, 75, new AlwaysSuccess()));
+        $checks         = new ArrayObject(array_fill(0, 75, new AlwaysSuccess()));
 
         ob_start();
         $this->reporter->onStart($checks, []);
@@ -158,11 +163,11 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testSummaryAllSuccessful(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 20; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
@@ -176,16 +181,16 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testSummaryWithWarnings(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Warning();
         }
 
@@ -199,21 +204,21 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testSummaryWithFailures(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Warning();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Failure();
         }
 
@@ -227,26 +232,26 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testSummaryWithUnknowns(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Warning();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Failure();
         }
 
         for ($x = 0; $x < 5; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Unknown();
         }
 
@@ -260,15 +265,15 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testWarnings(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
-        $checks[] = $check = new AlwaysSuccess();
+        $checks[]        = $check = new AlwaysSuccess();
         $results[$check] = new Warning('foo');
 
         ob_start();
@@ -284,15 +289,15 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testFailures(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
-        $checks[] = $check = new AlwaysSuccess();
+        $checks[]        = $check = new AlwaysSuccess();
         $results[$check] = new Failure('bar');
 
         ob_start();
@@ -308,15 +313,15 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testUnknowns(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 
-        $checks[] = $check = new AlwaysSuccess();
+        $checks[]        = $check = new AlwaysSuccess();
         $results[$check] = new Unknown('baz');
 
         ob_start();
@@ -332,11 +337,11 @@ class BasicConsoleReporterTest extends TestCase
 
     public function testStoppedNotice(): void
     {
-        $checks = new ArrayObject();
-        $check = null;
+        $checks  = new ArrayObject();
+        $check   = null;
         $results = new Collection();
         for ($x = 0; $x < 15; $x++) {
-            $checks[] = $check = new AlwaysSuccess();
+            $checks[]        = $check = new AlwaysSuccess();
             $results[$check] = new Success();
         }
 

--- a/test/DirWritableTest.php
+++ b/test/DirWritableTest.php
@@ -14,9 +14,7 @@ class DirWritableTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $checkClass = DirWritable::class;
 
     /**
@@ -32,6 +30,7 @@ class DirWritableTest extends TestCase
 
     /**
      * @dataProvider providerValidConstructorArguments
+     * @param array $arguments
      */
     public function testConstructor($arguments): void
     {
@@ -43,14 +42,14 @@ class DirWritableTest extends TestCase
         return [
             [__DIR__],
             [vfsStream::setup()->url()],
-            [[__DIR__, vfsStream::setup()->url()]]
+            [[__DIR__, vfsStream::setup()->url()]],
         ];
     }
 
     public function testCheckSuccessSinglePath(): void
     {
         $object = new DirWritable(vfsStream::setup()->url());
-        $r = $object->check();
+        $r      = $object->check();
         self::assertInstanceOf(Success::class, $r);
         self::assertEquals('The path is a writable directory.', $r->getMessage());
     }
@@ -58,7 +57,7 @@ class DirWritableTest extends TestCase
     public function testCheckSuccessMultiplePaths(): void
     {
         $object = new DirWritable([__DIR__, vfsStream::setup()->url()]);
-        $r = $object->check();
+        $r      = $object->check();
         self::assertInstanceOf(Success::class, $r);
         self::assertEquals('All paths are writable directories.', $r->getMessage());
     }
@@ -66,7 +65,7 @@ class DirWritableTest extends TestCase
     public function testCheckFailureSingleInvalidDir(): void
     {
         $object = new DirWritable('notadir');
-        $r = $object->check();
+        $r      = $object->check();
         self::assertInstanceOf(Failure::class, $r);
         self::assertStringContainsString('notadir is not a valid directory.', $r->getMessage());
     }
@@ -74,7 +73,7 @@ class DirWritableTest extends TestCase
     public function testCheckFailureMultipleInvalidDirs(): void
     {
         $object = new DirWritable(['notadir1', 'notadir2']);
-        $r = $object->check();
+        $r      = $object->check();
         self::assertInstanceOf(Failure::class, $r);
         self::assertStringContainsString(
             'The following paths are not valid directories: notadir1, notadir2.',
@@ -84,22 +83,22 @@ class DirWritableTest extends TestCase
 
     public function testCheckFailureSingleUnwritableDir(): void
     {
-        $root = vfsStream::setup();
+        $root          = vfsStream::setup();
         $unwritableDir = vfsStream::newDirectory('unwritabledir', 000)->at($root);
-        $object = new DirWritable($unwritableDir->url());
-        $r = $object->check();
+        $object        = new DirWritable($unwritableDir->url());
+        $r             = $object->check();
         self::assertInstanceOf(Failure::class, $r);
         self::assertEquals('vfs://root/unwritabledir directory is not writable.', $r->getMessage());
     }
 
     public function testCheckFailureMultipleUnwritableDirs(): void
     {
-        $root = vfsStream::setup();
+        $root           = vfsStream::setup();
         $unwritableDir1 = vfsStream::newDirectory('unwritabledir1', 000)->at($root);
         $unwritableDir2 = vfsStream::newDirectory('unwritabledir2', 000)->at($root);
 
         $object = new DirWritable([$unwritableDir1->url(), $unwritableDir2->url()]);
-        $r = $object->check();
+        $r      = $object->check();
         self::assertInstanceOf(Failure::class, $r);
         self::assertEquals(
             'The following directories are not writable: vfs://root/unwritabledir1, vfs://root/unwritabledir2.',

--- a/test/DiskFreeTest.php
+++ b/test/DiskFreeTest.php
@@ -9,45 +9,64 @@ use Laminas\Diagnostics\Result\SuccessInterface;
 use Laminas\Diagnostics\Result\WarningInterface;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+use function disk_free_space;
+use function is_writable;
+use function pow;
+use function sys_get_temp_dir;
+
 /**
  * Bytes conversion tests borrowed from Jerity project:
  *     https://github.com/jerity/jerity/blob/master/tests/Util/NumberTest.php
  *     authors:   Dave Ingram <dave@dmi.me.uk>, Nick Pope <nick@nickpope.me.uk>
  *     license:   http://creativecommons.org/licenses/BSD/ CC-BSD
  *     copyright: Copyright (c) 2010, Dave Ingram, Nick Pope
-
  */
 class DiskFreeTest extends TestCase
 {
     public static function stringToBytesProvider(): array
     {
-        $values = [1, 10, 12.34];
-        $prefix_symbol = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'K', 'M', 'G'];
-        $prefix_name = [
-            '', 'kilo', 'mega', 'giga', 'tera', 'peta',
-            'exa', 'zetta', 'kibi', 'mebi', 'gibi', 'tebi',
-            'pebi', 'exbi', 'kilo', 'mega', 'giga',
+        $values         = [1, 10, 12.34];
+        $prefixSymbol   = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'K', 'M', 'G'];
+        $prefixName     = [
+            '',
+            'kilo',
+            'mega',
+            'giga',
+            'tera',
+            'peta',
+            'exa',
+            'zetta',
+            'kibi',
+            'mebi',
+            'gibi',
+            'tebi',
+            'pebi',
+            'exbi',
+            'kilo',
+            'mega',
+            'giga',
         ];
-        $multiplier_base = [10, 10, 10, 10, 10, 10, 10, 10, 2, 2, 2, 2, 2, 2, 2, 2, 2];
-        $multiplier_exp = [0, 3, 6, 9, 12, 15, 18, 21, 10, 20, 30, 40, 50, 60, 10, 20, 30];
-        $data = [];
+        $multiplierBase = [10, 10, 10, 10, 10, 10, 10, 10, 2, 2, 2, 2, 2, 2, 2, 2, 2];
+        $multiplierExp  = [0, 3, 6, 9, 12, 15, 18, 21, 10, 20, 30, 40, 50, 60, 10, 20, 30];
+        $data           = [];
         foreach ($values as $value) {
-            for ($i = 0; $i < count($prefix_symbol); $i++) {
-                $v = $value * pow($multiplier_base[$i], $multiplier_exp[$i]);
-                $jedec = ($i >= count($prefix_symbol) - 4);
-                $data[] = ["{$value}{$prefix_symbol[$i]}B", $jedec, $v];
-                $data[] = ["{$value}{$prefix_symbol[$i]}Bps", $jedec, $v];
-                $data[] = ["{$value}{$prefix_symbol[$i]}b", $jedec, $v / 8];
-                $data[] = ["{$value}{$prefix_symbol[$i]}bps", $jedec, $v / 8];
-                $data[] = ["{$value} {$prefix_symbol[$i]}B", $jedec, $v];
-                $data[] = ["{$value} {$prefix_symbol[$i]}Bps", $jedec, $v];
-                $data[] = ["{$value} {$prefix_symbol[$i]}b", $jedec, $v / 8];
-                $data[] = ["{$value} {$prefix_symbol[$i]}bps", $jedec, $v / 8];
-                $postfix = ($value == 1 ? '' : 's');
-                $data[] = ["{$value}{$prefix_name[$i]}byte{$postfix}", $jedec, $v];
-                $data[] = ["{$value}{$prefix_name[$i]}bit{$postfix}", $jedec, $v / 8];
-                $data[] = ["{$value} {$prefix_name[$i]}byte{$postfix}", $jedec, $v];
-                $data[] = ["{$value} {$prefix_name[$i]}bit{$postfix}", $jedec, $v / 8];
+            for ($i = 0; $i < count($prefixSymbol); $i++) {
+                $v       = $value * pow($multiplierBase[$i], $multiplierExp[$i]);
+                $jedec   = $i >= count($prefixSymbol) - 4;
+                $data[]  = ["{$value}{$prefixSymbol[$i]}B", $jedec, $v];
+                $data[]  = ["{$value}{$prefixSymbol[$i]}Bps", $jedec, $v];
+                $data[]  = ["{$value}{$prefixSymbol[$i]}b", $jedec, $v / 8];
+                $data[]  = ["{$value}{$prefixSymbol[$i]}bps", $jedec, $v / 8];
+                $data[]  = ["{$value} {$prefixSymbol[$i]}B", $jedec, $v];
+                $data[]  = ["{$value} {$prefixSymbol[$i]}Bps", $jedec, $v];
+                $data[]  = ["{$value} {$prefixSymbol[$i]}b", $jedec, $v / 8];
+                $data[]  = ["{$value} {$prefixSymbol[$i]}bps", $jedec, $v / 8];
+                $postfix = $value === 1 ? '' : 's';
+                $data[]  = ["{$value}{$prefixName[$i]}byte{$postfix}", $jedec, $v];
+                $data[]  = ["{$value}{$prefixName[$i]}bit{$postfix}", $jedec, $v / 8];
+                $data[]  = ["{$value} {$prefixName[$i]}byte{$postfix}", $jedec, $v];
+                $data[]  = ["{$value} {$prefixName[$i]}bit{$postfix}", $jedec, $v / 8];
             }
         }
 
@@ -73,14 +92,12 @@ class DiskFreeTest extends TestCase
             [1048576,          5, '1 MiB'],
             [1024,             5, '1 KiB'],
             [999,              5, '999 B'],
-
             [1351079888211148, 0, '1 PiB'],
             [1319413953331,    0, '1 TiB'],
             [1288490190,       0, '1 GiB'],
             [1258291,          0, '1 MiB'],
             [1228,             0, '1 KiB'],
             [999,              0, '999 B'],
-
             [1351079888211148, 1, '1.2 PiB'],
             [1319413953331,    1, '1.2 TiB'],
             [1288490190,       1, '1.2 GiB'],
@@ -92,6 +109,9 @@ class DiskFreeTest extends TestCase
 
     /**
      * @dataProvider  stringToBytesProvider
+     * @param string $a
+     * @param bool $b
+     * @param int|float $c
      */
     public function testStringToBytes($a, $b, $c): void
     {
@@ -100,6 +120,10 @@ class DiskFreeTest extends TestCase
 
     /**
      * @dataProvider  stringToBytesExceptionProvider
+     * @param string $a
+     * @param bool $b
+     * @param string $c
+     * @psalm-param class-string $c
      */
     public function testStringToBytesException($a, $b, $c): void
     {
@@ -109,6 +133,9 @@ class DiskFreeTest extends TestCase
 
     /**
      * @dataProvider  bytesToStringProvider
+     * @param int $bytes
+     * @param int $precision
+     * @param string $string
      */
     public function testBytesToString($bytes, $precision, $string): void
     {
@@ -117,40 +144,40 @@ class DiskFreeTest extends TestCase
 
     public function testJitFreeSpace(): void
     {
-        $tmp = $this->getTempDir();
+        $tmp          = $this->getTempDir();
         $freeRightNow = disk_free_space($tmp);
-        $check = new DiskFree($freeRightNow * 0.5, $tmp);
-        $result = $check->check();
+        $check        = new DiskFree($freeRightNow * 0.5, $tmp);
+        $result       = $check->check();
 
         self::assertInstanceof(SuccessInterface::class, $result);
 
         $freeRightNow = disk_free_space($tmp);
-        $check = new DiskFree($freeRightNow + 1073741824, $tmp);
-        $result = $check->check();
+        $check        = new DiskFree($freeRightNow + 1073741824, $tmp);
+        $result       = $check->check();
 
         self::assertInstanceof(FailureInterface::class, $result);
     }
 
     public function testSpaceWithStringConversion(): void
     {
-        $tmp = $this->getTempDir();
+        $tmp          = $this->getTempDir();
         $freeRightNow = disk_free_space($tmp);
         if ($freeRightNow < 1024) {
             self::markTestSkipped('There is less that 1024 bytes free in temp dir');
         }
 
         // give some margin of error
-        $freeRightNow *= 0.9;
+        $freeRightNow      *= 0.9;
         $freeRightNowString = DiskFree::bytesToString($freeRightNow);
-        $check = new DiskFree($freeRightNowString, $tmp);
-        $result = $check->check();
+        $check              = new DiskFree($freeRightNowString, $tmp);
+        $result             = $check->check();
 
         self::assertInstanceof(SuccessInterface::class, $result);
     }
 
     public function testInvalidPathShouldReturnWarning(): void
     {
-        $check = new DiskFree(1024, __DIR__ . '/someImprobablePath99999999999999999');
+        $check  = new DiskFree(1024, __DIR__ . '/someImprobablePath99999999999999999');
         $result = $check->check();
         self::assertInstanceof(WarningInterface::class, $result);
     }
@@ -179,6 +206,9 @@ class DiskFreeTest extends TestCase
         new DiskFree(1024, 100);
     }
 
+    /**
+     * @return string
+     */
     protected function getTempDir()
     {
         // try to retrieve tmp dir

--- a/test/DoctrineMigrationTest.php
+++ b/test/DoctrineMigrationTest.php
@@ -13,10 +13,16 @@ use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\Version;
 use Generator;
+use InvalidArgumentException;
 use Laminas\Diagnostics\Check\DoctrineMigration;
 use Laminas\Diagnostics\Result\FailureInterface;
 use Laminas\Diagnostics\Result\SuccessInterface;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function array_map;
+use function class_exists;
+use function interface_exists;
 
 class DoctrineMigrationTest extends TestCase
 {
@@ -36,7 +42,7 @@ class DoctrineMigrationTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $migrationMock = $this->createMock(AbstractMigration::class);
+        $migrationMock       = $this->createMock(AbstractMigration::class);
         $availableMigrations = array_map(static function ($version) use ($migrationMock) {
             return new AvailableMigration(new Version($version), $migrationMock);
         }, $availableVersions);
@@ -73,7 +79,7 @@ class DoctrineMigrationTest extends TestCase
             ->method('getMetadataStorage')
             ->willReturn($metadataStorage);
 
-        $check = new DoctrineMigration($dependencyFactory);
+        $check  = new DoctrineMigration($dependencyFactory);
         $result = $check->check();
 
         self::assertInstanceof($expectedResult, $result);
@@ -105,7 +111,7 @@ class DoctrineMigrationTest extends TestCase
             ->method('getMigratedVersions')
             ->willReturn($migratedVersions);
 
-        $check = new DoctrineMigration($configuration);
+        $check  = new DoctrineMigration($configuration);
         $result = $check->check();
 
         self::assertInstanceof($expectedResult, $result);
@@ -113,10 +119,10 @@ class DoctrineMigrationTest extends TestCase
 
     public function testThrowsExceptionForInvalidInput(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid Argument for DoctrineMigration check.');
 
-        new DoctrineMigration(new \stdClass());
+        new DoctrineMigration(new stdClass());
     }
 
     public function testConstructorDoesNotOpenConnectionToDatabaseDoctrineVersion3(): void
@@ -170,17 +176,17 @@ class DoctrineMigrationTest extends TestCase
         yield 'everything migrated' => [
             ['Version1', 'Version2'],
             ['Version1', 'Version2'],
-            SuccessInterface::class
+            SuccessInterface::class,
         ];
         yield 'not all migration migrated' => [
             ['Version1', 'Version2'],
             ['Version1'],
-            FailureInterface::class
+            FailureInterface::class,
         ];
         yield 'not existing migration migrated' => [
             ['Version1'],
             ['Version1', 'Version2'],
-            FailureInterface::class
+            FailureInterface::class,
         ];
     }
 

--- a/test/GuzzleHttpServiceTest.php
+++ b/test/GuzzleHttpServiceTest.php
@@ -12,20 +12,23 @@ use Laminas\Diagnostics\Result\FailureInterface;
 use Laminas\Diagnostics\Result\SuccessInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use ReflectionClass;
 use ReflectionProperty;
+
+use function class_exists;
+use function json_decode;
+use function sprintf;
 
 class GuzzleHttpServiceTest extends TestCase
 {
-    protected $responseTemplate = <<< 'EOR'
-HTTP/1.1 %d
-
-%s
-EOR;
+    /** @var string */
+    protected $responseTemplate = <<<'EOR'
+        HTTP/1.1 %d
+        
+        %s
+        EOR;
 
     /**
      * @param array $params
-     *
      * @dataProvider couchDbProvider
      */
     public function testCouchDbCheck(array $params): void
@@ -36,6 +39,12 @@ EOR;
 
     /**
      * @dataProvider checkProvider
+     * @param null|string $content
+     * @param string $actualContent
+     * @param int $actualStatusCode
+     * @param string $resultClass
+     * @param string $method
+     * @param null|string $body
      */
     public function testGuzzleCheck(
         $content,
@@ -49,7 +58,7 @@ EOR;
             self::markTestSkipped('guzzlehttp/guzzle not installed.');
         }
 
-        $check = new GuzzleHttpService(
+        $check  = new GuzzleHttpService(
             'http://www.example.com/foobar',
             [],
             [],
@@ -130,19 +139,28 @@ EOR;
     public function couchDbProvider(): array
     {
         return [
-            'url' => [[
-                'url' => 'http://root:party@localhost/hello'
-            ]],
-            'options' => [[
-                'host' => '127.0.0.1',
-                'port' => '443',
-                'username' => 'test',
-                'password' => 'test',
-                'dbname' => 'database'
-            ]],
+            'url'     => [
+                [
+                    'url' => 'http://root:party@localhost/hello',
+                ],
+            ],
+            'options' => [
+                [
+                    'host'     => '127.0.0.1',
+                    'port'     => '443',
+                    'username' => 'test',
+                    'password' => 'test',
+                    'dbname'   => 'database',
+                ],
+            ],
         ];
     }
 
+    /**
+     * @param int $statusCode
+     * @param null|string $content
+     * @return GuzzleClient
+     */
     private function getMockGuzzleClient($statusCode = 200, $content = null)
     {
         $response = Message::parseResponse(sprintf($this->responseTemplate, $statusCode, (string) $content));

--- a/test/OpCacheMemoryTest.php
+++ b/test/OpCacheMemoryTest.php
@@ -4,11 +4,13 @@ namespace LaminasTest\Diagnostics;
 
 use Laminas\Diagnostics\Check\OpCacheMemory;
 
-/**
- * @author Kevin Bond <kevinbond@gmail.com>
- */
 class OpCacheMemoryTest extends AbstractMemoryTest
 {
+    /**
+     * @param int|string $warningThreshold
+     * @param int|string $criticalThreshold
+     * @return OpCacheMemory
+     */
     protected function createCheck($warningThreshold, $criticalThreshold)
     {
         return new OpCacheMemory($warningThreshold, $criticalThreshold);

--- a/test/ResultCollectionTest.php
+++ b/test/ResultCollectionTest.php
@@ -15,9 +15,7 @@ use stdClass;
 
 class ResultCollectionTest extends TestCase
 {
-    /**
-     * @var Collection
-     */
+    /** @var Collection */
     protected $collection;
 
     protected function setUp(): void
@@ -31,8 +29,8 @@ class ResultCollectionTest extends TestCase
             [0],
             [1],
             ['foo'],
-            [new stdClass],
-            [new ArrayObject],
+            [new stdClass()],
+            [new ArrayObject()],
             [new Success()],
         ];
     }
@@ -43,8 +41,8 @@ class ResultCollectionTest extends TestCase
             [0],
             [1],
             ['foo'],
-            [new stdClass],
-            [new ArrayObject],
+            [new stdClass()],
+            [new ArrayObject()],
             [new AlwaysSuccess()],
         ];
     }
@@ -76,7 +74,7 @@ class ResultCollectionTest extends TestCase
 
     public function testBasicGettingAndSetting(): void
     {
-        $test = new AlwaysSuccess();
+        $test   = new AlwaysSuccess();
         $result = new Success();
 
         $this->collection[$test] = $result;
@@ -88,6 +86,7 @@ class ResultCollectionTest extends TestCase
 
     /**
      * @dataProvider invalidKeysProvider
+     * @param mixed $key
      */
     public function testInvalidKeySet($key): void
     {
@@ -99,6 +98,7 @@ class ResultCollectionTest extends TestCase
 
     /**
      * @dataProvider invalidKeysProvider
+     * @param mixed $key
      */
     public function testInvalidKeyGet($key): void
     {
@@ -110,6 +110,7 @@ class ResultCollectionTest extends TestCase
 
     /**
      * @dataProvider invalidKeysProvider
+     * @param mixed $key
      */
     public function testInvalidKeyUnset($key): void
     {
@@ -119,6 +120,7 @@ class ResultCollectionTest extends TestCase
 
     /**
      * @dataProvider invalidKeysProvider
+     * @param mixed $key
      */
     public function testInvalidKeyExists($key): void
     {
@@ -128,6 +130,7 @@ class ResultCollectionTest extends TestCase
 
     /**
      * @dataProvider invalidValuesProvider
+     * @param mixed $value
      */
     public function testInvalidValuesSet($value): void
     {
@@ -144,47 +147,47 @@ class ResultCollectionTest extends TestCase
         self::assertEquals(0, $this->collection->getFailureCount());
         self::assertEquals(0, $this->collection->getUnknownCount());
 
-        $success1 = new Success();
-        $test1 = new AlwaysSuccess();
+        $success1                 = new Success();
+        $test1                    = new AlwaysSuccess();
         $this->collection[$test1] = $success1;
         self::assertEquals(1, $this->collection->getSuccessCount());
         self::assertEquals(0, $this->collection->getWarningCount());
         self::assertEquals(0, $this->collection->getFailureCount());
         self::assertEquals(0, $this->collection->getUnknownCount());
 
-        $success2 = new Success();
-        $test2 = new AlwaysSuccess();
+        $success2                 = new Success();
+        $test2                    = new AlwaysSuccess();
         $this->collection[$test2] = $success2;
         self::assertEquals(2, $this->collection->getSuccessCount());
         self::assertEquals(0, $this->collection->getWarningCount());
         self::assertEquals(0, $this->collection->getFailureCount());
         self::assertEquals(0, $this->collection->getUnknownCount());
 
-        $failure1 = new Failure();
-        $test3 = new AlwaysSuccess();
+        $failure1                 = new Failure();
+        $test3                    = new AlwaysSuccess();
         $this->collection[$test3] = $failure1;
         self::assertEquals(2, $this->collection->getSuccessCount());
         self::assertEquals(0, $this->collection->getWarningCount());
         self::assertEquals(1, $this->collection->getFailureCount());
         self::assertEquals(0, $this->collection->getUnknownCount());
 
-        $warning1 = new Warning();
-        $test4 = new AlwaysSuccess();
+        $warning1                 = new Warning();
+        $test4                    = new AlwaysSuccess();
         $this->collection[$test4] = $warning1;
         self::assertEquals(2, $this->collection->getSuccessCount());
         self::assertEquals(1, $this->collection->getWarningCount());
         self::assertEquals(1, $this->collection->getFailureCount());
         self::assertEquals(0, $this->collection->getUnknownCount());
 
-        $unknown = new Unknown();
-        $test5 = new AlwaysSuccess();
+        $unknown                  = new Unknown();
+        $test5                    = new AlwaysSuccess();
         $this->collection[$test5] = $unknown;
         self::assertEquals(2, $this->collection->getSuccessCount());
         self::assertEquals(1, $this->collection->getWarningCount());
         self::assertEquals(1, $this->collection->getFailureCount());
         self::assertEquals(1, $this->collection->getUnknownCount());
 
-        $failure2 = new Failure();
+        $failure2                 = new Failure();
         $this->collection[$test2] = $failure2;
         self::assertEquals(1, $this->collection->getSuccessCount());
         self::assertEquals(1, $this->collection->getWarningCount());
@@ -237,13 +240,13 @@ class ResultCollectionTest extends TestCase
     public function testIteration(): void
     {
         $tests = $results = [];
-        $test = $result = null;
+        $test  = $result = null;
 
         for ($x = 0; $x < 10; $x++) {
-            $test     = new AlwaysSuccess();
-            $result   = new Success();
-            $tests[]  = $test;
-            $results[] = $result;
+            $test                    = new AlwaysSuccess();
+            $result                  = new Success();
+            $tests[]                 = $test;
+            $results[]               = $result;
             $this->collection[$test] = $result;
         }
 

--- a/test/RunnerTest.php
+++ b/test/RunnerTest.php
@@ -28,11 +28,15 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
 
+use function is_string;
+
+use const E_USER_ERROR;
+use const E_WARNING;
+use const PHP_MAJOR_VERSION;
+
 class RunnerTest extends TestCase
 {
-    /**
-     * @var Runner
-     */
+    /** @var Runner */
     protected $runner;
 
     protected function setUp(): void
@@ -61,18 +65,18 @@ class RunnerTest extends TestCase
             ],
             [
                 true,
-                Success::class
+                Success::class,
             ],
             [
                 false,
-                Failure::class
+                Failure::class,
             ],
             [
                 null,
                 Failure::class,
             ],
             [
-                new \stdClass(),
+                new stdClass(),
                 Failure::class,
             ],
             [
@@ -89,7 +93,7 @@ class RunnerTest extends TestCase
 
         $this->runner->setConfig([
             'break_on_failure'     => true,
-            'catch_error_severity' => 100
+            'catch_error_severity' => 100,
         ]);
 
         self::assertTrue($this->runner->getBreakOnFailure());
@@ -103,14 +107,14 @@ class RunnerTest extends TestCase
 
         $this->runner = new Runner([
             'break_on_failure'     => true,
-            'catch_error_severity' => 300
+            'catch_error_severity' => 300,
         ]);
 
         self::assertTrue($this->runner->getBreakOnFailure());
         self::assertSame(300, $this->runner->getCatchErrorSeverity());
         self::assertEquals([
             'break_on_failure'     => true,
-            'catch_error_severity' => 300
+            'catch_error_severity' => 300,
         ], $this->runner->getConfig());
     }
 
@@ -124,7 +128,7 @@ class RunnerTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
         $this->runner->setConfig([
-            'foo' => 'bar'
+            'foo' => 'bar',
         ]);
     }
 
@@ -136,7 +140,7 @@ class RunnerTest extends TestCase
         $this->runner->addCheck($check1);
         $this->runner->addChecks([
             $check2,
-            $check3
+            $check3,
         ]);
         self::assertContains($check1, $this->runner->getChecks());
         self::assertContains($check2, $this->runner->getChecks());
@@ -167,8 +171,8 @@ class RunnerTest extends TestCase
 
     public function testConstructionWithChecks(): void
     {
-        $check1 = new AlwaysSuccess();
-        $check2 = new AlwaysSuccess();
+        $check1       = new AlwaysSuccess();
+        $check2       = new AlwaysSuccess();
         $this->runner = new Runner([], [$check1, $check2]);
         self::assertCount(2, $this->runner->getChecks());
         self::assertContains($check1, $this->runner->getChecks());
@@ -177,7 +181,7 @@ class RunnerTest extends TestCase
 
     public function testConstructionWithReporter(): void
     {
-        $reporter = $this->createMock(AbstractReporter::class);
+        $reporter     = $this->createMock(AbstractReporter::class);
         $this->runner = new Runner([], [], $reporter);
         self::assertCount(1, $this->runner->getReporters());
         self::assertContains($reporter, $this->runner->getReporters());
@@ -219,8 +223,7 @@ class RunnerTest extends TestCase
     {
         $this->runner->addCheck(new AlwaysSuccess());
         $mock = $this->createMock(AbstractReporter::class);
-        $mock->expects(self
-            ::once())
+        $mock->expects(self::once())
             ->method('onStart')
             ->with(self::isInstanceOf(ArrayObject::class), self::isType('array'));
         $this->runner->addReporter($mock);
@@ -250,11 +253,10 @@ class RunnerTest extends TestCase
     public function testAliasIsKeptAfterRun(): void
     {
         $checkAlias = 'foo';
-        $check = new AlwaysSuccess();
+        $check      = new AlwaysSuccess();
         $this->runner->addCheck($check, $checkAlias);
         $mock = $this->createMock(AbstractReporter::class);
-        $mock->expects(self
-            ::once())
+        $mock->expects(self::once())
             ->method('onAfterRun')
             ->with(self::identicalTo($check), $check->check(), $checkAlias);
         $this->runner->addReporter($mock);
@@ -263,6 +265,8 @@ class RunnerTest extends TestCase
 
     /**
      * @dataProvider checksAndResultsProvider
+     * @param mixed $value
+     * @param mixed $expectedResult
      */
     public function testStandardResults($value, $expectedResult): void
     {
@@ -288,7 +292,7 @@ class RunnerTest extends TestCase
     public function testExceptionResultsInFailure(): void
     {
         $exception = new Exception();
-        $check = new ThrowException($exception);
+        $check     = new ThrowException($exception);
         $this->runner->addCheck($check);
         $results = $this->runner->run();
         self::assertInstanceOf(Failure::class, $results[$check]);
@@ -348,8 +352,7 @@ class RunnerTest extends TestCase
             ->will(self::onConsecutiveCalls(
                 false,
                 true
-            ))
-        ;
+            ));
         $this->runner->addReporter($mock);
 
         $results = $this->runner->run();
@@ -374,8 +377,7 @@ class RunnerTest extends TestCase
             ->will(self::onConsecutiveCalls(
                 false,
                 true
-            ))
-        ;
+            ));
         $this->runner->addReporter($mock);
 
         $results = $this->runner->run();

--- a/test/TestAsset/Check/AlwaysFailure.php
+++ b/test/TestAsset/Check/AlwaysFailure.php
@@ -7,6 +7,7 @@ use Laminas\Diagnostics\Result\Failure;
 
 class AlwaysFailure extends AbstractCheck
 {
+    /** @return Failure */
     public function check()
     {
         return new Failure('This check always results in failure!');

--- a/test/TestAsset/Check/AlwaysSuccess.php
+++ b/test/TestAsset/Check/AlwaysSuccess.php
@@ -7,6 +7,7 @@ use Laminas\Diagnostics\Result\Success;
 
 class AlwaysSuccess extends AbstractCheck
 {
+    /** @return Success */
     public function check()
     {
         return new Success('This check always results in success!');

--- a/test/TestAsset/Check/ReturnThis.php
+++ b/test/TestAsset/Check/ReturnThis.php
@@ -6,13 +6,16 @@ use Laminas\Diagnostics\Check\AbstractCheck;
 
 class ReturnThis extends AbstractCheck
 {
+    /** @var mixed */
     protected $value;
 
+    /** @param mixed $value */
     public function __construct($value)
     {
         $this->value = $value;
     }
 
+    /** @return mixed */
     public function check()
     {
         return $this->value;

--- a/test/TestAsset/Check/SecurityAdvisory.php
+++ b/test/TestAsset/Check/SecurityAdvisory.php
@@ -2,14 +2,11 @@
 
 namespace LaminasTest\Diagnostics\TestAsset\Check;
 
-use Laminas\Diagnostics\Check\SecurityAdvisory as BaseCheck;
 use Enlightn\SecurityChecker\AdvisoryAnalyzer;
+use Laminas\Diagnostics\Check\SecurityAdvisory as BaseCheck;
 
 class SecurityAdvisory extends BaseCheck
 {
-    /**
-     * @param \Enlightn\SecurityChecker\AdvisoryAnalyzer $advisoryAnalyzer
-     */
     public function setAdvisoryAnalyzer(AdvisoryAnalyzer $advisoryAnalyzer): void
     {
         $this->advisoryAnalyzer = $advisoryAnalyzer;

--- a/test/TestAsset/Check/TriggerUserError.php
+++ b/test/TestAsset/Check/TriggerUserError.php
@@ -4,15 +4,27 @@ namespace LaminasTest\Diagnostics\TestAsset\Check;
 
 use Laminas\Diagnostics\Check\AbstractCheck;
 
+use function trigger_error;
+
 class TriggerUserError extends AbstractCheck
 {
+    /** @var string */
     protected $label = '';
 
+    /** @var string */
     protected $message;
+
+    /** @var int */
     protected $severity;
 
+    /** @var bool */
     protected $result = true;
 
+    /**
+     * @param string $message
+     * @param int $severity
+     * @param bool $result
+     */
     public function __construct($message, $severity, $result = true)
     {
         $this->message  = $message;
@@ -20,6 +32,7 @@ class TriggerUserError extends AbstractCheck
         $this->result   = $result;
     }
 
+    /** @return bool */
     public function check()
     {
         trigger_error($this->message, $this->severity);

--- a/test/TestAsset/Check/TriggerWarning.php
+++ b/test/TestAsset/Check/TriggerWarning.php
@@ -5,8 +5,11 @@ namespace LaminasTest\Diagnostics\TestAsset\Check;
 use Laminas\Diagnostics\Check\AbstractCheck;
 use Laminas\Diagnostics\Result\Success;
 
+use function strpos;
+
 class TriggerWarning extends AbstractCheck
 {
+    /** @return Success */
     public function check()
     {
         strpos(); // <-- this will throw a real warning

--- a/test/TestAsset/Reporter/AbstractReporter.php
+++ b/test/TestAsset/Reporter/AbstractReporter.php
@@ -10,14 +10,17 @@ use Laminas\Diagnostics\Runner\Reporter\ReporterInterface;
 
 abstract class AbstractReporter implements ReporterInterface
 {
+    /** @param array $runnerConfig */
     public function onStart(ArrayObject $checks, $runnerConfig)
     {
     }
 
+    /** @param string|null $checkAlias */
     public function onBeforeRun(Check $check, $checkAlias = null)
     {
     }
 
+    /** @param string|null $checkAlias */
     public function onAfterRun(Check $check, Result $result, $checkAlias = null)
     {
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This patch updates to laminas-coding-standard v2, with the exception of the `declare(strict_types=1)` requirement.

A few comparisons were updated to use strict equality, but only where the other value type was known; tests continue to run locally.
