### PR TITLE
Allow PHP 8.2, drop PHP 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.4.99"
+            "php": "8.0.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -33,20 +33,20 @@
         }
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "enlightn/security-checker": "^1.10"
     },
     "require-dev": {
-        "doctrine/migrations": "^2.0 || ^3.0",
+        "doctrine/migrations": "^2.0 || ^3.5.2",
         "guzzlehttp/guzzle": "^7.5.0",
         "laminas/laminas-coding-standard": "~2.4.0",
-        "laminas/laminas-loader": "^2.0",
+        "laminas/laminas-loader": "^2.9",
         "mikey179/vfsstream": "^1.6.11",
-        "php-amqplib/php-amqplib": "^2.0 || ^3.0",
+        "php-amqplib/php-amqplib": "^2.0 || ^3.4",
         "phpunit/phpunit": "^9.5.26",
-        "psalm/plugin-phpunit": "^0.18.0",
+        "psalm/plugin-phpunit": "^0.18.3",
         "predis/predis": "^2.0.3",
-        "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0.14",
         "vimeo/psalm": "^4.29.0"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b79e0e60b53a7b235491a70a430e0d7",
+    "content-hash": "dfa22555d5015ce39e5cdabb464a05f1",
     "packages": [
         {
             "name": "enlightn/security-checker",
@@ -3078,27 +3078,27 @@
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b"
+                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/d0589ec9dd48365fd95ad10d1c906efd7711c16b",
-                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/51ed9c3fa42d1098a9997571730c0cbf42d078d3",
+                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-loader": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "~9.5.25"
             },
             "type": "library",
             "autoload": {
@@ -3130,7 +3130,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-02T18:30:53+00:00"
+            "time": "2022-10-16T12:50:49+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -6216,11 +6216,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.99"
+        "php": "8.0.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -159,9 +159,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Check/CpuPerformance.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>string</code>
-    </InvalidNullableReturnType>
     <InvalidScalarArgument occurrences="15">
       <code>$a</code>
       <code>$a</code>
@@ -183,14 +180,11 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="1">
-      <code>bcdiv(bcpow(bcadd($a, $b), 2), bcmul(4, $t), $precision)</code>
-    </NullableReturnStatement>
     <PossiblyNullArgument occurrences="4">
       <code>$b</code>
       <code>$b</code>
       <code>$b</code>
-      <code>$x</code>
+      <code>bcsqrt(2)</code>
     </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>CpuPerformance</code>
@@ -200,9 +194,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/DirReadable.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;dir</code>
-    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$path</code>
     </InvalidPropertyAssignmentValue>
@@ -223,14 +214,14 @@
       <code>current($nonDirs)</code>
       <code>current($unreadable)</code>
     </MixedOperand>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;dir</code>
+    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>DirReadable</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Check/DirWritable.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;dir</code>
-    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$path</code>
     </InvalidPropertyAssignmentValue>
@@ -249,6 +240,9 @@
       <code>$nonDirs[]</code>
       <code>$unwritable[]</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;dir</code>
+    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>DirWritable</code>
     </PropertyNotSetInConstructor>
@@ -264,13 +258,10 @@
     <InvalidScalarArgument occurrences="1">
       <code>$free</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="3">
       <code>$a</code>
       <code>$a</code>
       <code>$k</code>
-      <code>$this-&gt;path</code>
-      <code>$this-&gt;path</code>
-      <code>$this-&gt;path</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1"/>
     <MixedAssignment occurrences="3">
@@ -281,9 +272,8 @@
     <MixedInferredReturnType occurrences="1">
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="3">
+    <MixedOperand occurrences="2">
       <code>$bytes</code>
-      <code>$this-&gt;path</code>
       <code>$x[$i]</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1">
@@ -302,12 +292,6 @@
       <code>! is_float($free)</code>
       <code>$free === false || ! is_float($free)</code>
     </TypeDoesNotContainType>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;path</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;path</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Check/DiskUsage.php">
     <DocblockTypeContradiction occurrences="3">
@@ -341,9 +325,6 @@
     </UndefinedMethod>
   </file>
   <file src="src/Check/ExtensionLoaded.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;extensions</code>
-    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$extensionName</code>
     </InvalidPropertyAssignmentValue>
@@ -371,6 +352,9 @@
       <code>$ext</code>
       <code>$ext</code>
     </MixedOperand>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;extensions</code>
+    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>ExtensionLoaded</code>
     </PropertyNotSetInConstructor>

--- a/src/Check/DiskFree.php
+++ b/src/Check/DiskFree.php
@@ -127,6 +127,13 @@ class DiskFree extends AbstractCheck implements CheckInterface
     ];
 
     /**
+     * The disk path to check.
+     *
+     * @internal
+     */
+    public string $path;
+
+    /**
      * @param  int|string                $size Minimum disk size in bytes or a valid byte string (IEC, SI or Jedec).
      * @param  string                    $path The disk path to check, i.e. '/tmp' or 'C:' (defaults to /)
      * @throws InvalidArgumentException

--- a/src/Check/DiskFree.php
+++ b/src/Check/DiskFree.php
@@ -130,8 +130,10 @@ class DiskFree extends AbstractCheck implements CheckInterface
      * The disk path to check.
      *
      * @internal
+     *
+     * @var string
      */
-    public string $path;
+    public $path;
 
     /**
      * @param  int|string                $size Minimum disk size in bytes or a valid byte string (IEC, SI or Jedec).


### PR DESCRIPTION
Signed-off-by: Ion Bazan <ion.bazan@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | /no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Allowing PHP 8.2 in `composer.json` and build matrix.

Tests failing because some `php8.2-*` extensions are not available in https://launchpad.net/~ondrej/+archive/ubuntu/php/ PPA yet.