### PR TITLE
Set extra result data fields

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/Check/AbstractCheck.php">
     <MissingConstructor occurrences="4">
       <code>$label</code>
@@ -1005,6 +1005,11 @@
     <MixedInferredReturnType occurrences="1">
       <code>Generator</code>
     </MixedInferredReturnType>
+  </file>
+  <file src="test/ExtensionLoadedTest.php">
+    <MixedArgument occurrences="1">
+      <code>$extensionName</code>
+    </MixedArgument>
   </file>
   <file src="test/GuzzleHttpServiceTest.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/Check/AbstractMemoryCheck.php
+++ b/src/Check/AbstractMemoryCheck.php
@@ -82,14 +82,14 @@ abstract class AbstractMemoryCheck extends AbstractCheck implements CheckInterfa
         );
 
         if ($percentUsed > $this->criticalThreshold) {
-            return new Failure($message);
+            return new Failure($message, $percentUsed);
         }
 
         if ($percentUsed > $this->warningThreshold) {
-            return new Warning($message);
+            return new Warning($message, $percentUsed);
         }
 
-        return new Success($message);
+        return new Success($message, $percentUsed);
     }
 
     /**

--- a/src/Check/ApcFragmentation.php
+++ b/src/Check/ApcFragmentation.php
@@ -134,13 +134,13 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
         $message = sprintf('%.0f%% memory fragmentation.', $fragPercent);
 
         if ($fragPercent > $this->criticalThreshold) {
-            return new Failure($message);
+            return new Failure($message, $fragPercent);
         }
 
         if ($fragPercent > $this->warningThreshold) {
-            return new Warning($message);
+            return new Warning($message, $fragPercent);
         }
 
-        return new Success($message);
+        return new Success($message, $fragPercent);
     }
 }

--- a/src/Check/DiskUsage.php
+++ b/src/Check/DiskUsage.php
@@ -95,13 +95,13 @@ class DiskUsage extends AbstractCheck implements CheckInterface
         $dp = ($du / $dt) * 100;
 
         if ($dp >= $this->criticalThreshold) {
-            return new Failure(sprintf('Disk usage too high: %2d percent.', $dp));
+            return new Failure(sprintf('Disk usage too high: %2d percent.', $dp), $dp);
         }
 
         if ($dp >= $this->warningThreshold) {
-            return new Warning(sprintf('Disk usage high: %2d percent.', $dp));
+            return new Warning(sprintf('Disk usage high: %2d percent.', $dp), $dp);
         }
 
-        return new Success(sprintf('Disk usage is %2d percent.', $dp));
+        return new Success(sprintf('Disk usage is %2d percent.', $dp), $dp);
     }
 }

--- a/src/Check/ExtensionLoaded.php
+++ b/src/Check/ExtensionLoaded.php
@@ -67,9 +67,9 @@ class ExtensionLoaded extends AbstractCheck implements CheckInterface
         }
         if (count($missing)) {
             if (count($missing) > 1) {
-                return new Failure('Extensions ' . implode(', ', $missing) . ' are not available.');
+                return new Failure('Extensions ' . implode(', ', $missing) . ' are not available.', $missing);
             } else {
-                return new Failure('Extension ' . implode('', $missing) . ' is not available.');
+                return new Failure('Extension ' . implode('', $missing) . ' is not available.', $missing);
             }
         } else {
             if (count($this->extensions) > 1) {

--- a/test/DiskUsageTest.php
+++ b/test/DiskUsageTest.php
@@ -41,16 +41,19 @@ final class DiskUsageTest extends TestCase
         $result = $check->check();
 
         self::assertInstanceof(SuccessInterface::class, $result);
+        self::assertSame($dp, $result->getData());
 
         $check  = new DiskUsage($dp - 1, 100, $this->getTempDir());
         $result = $check->check();
 
         self::assertInstanceof(WarningInterface::class, $result);
+        self::assertSame($dp, $result->getData());
 
         $check  = new DiskUsage(0, $dp - 1, $this->getTempDir());
         $result = $check->check();
 
         self::assertInstanceof(FailureInterface::class, $result);
+        self::assertSame($dp, $result->getData());
     }
 
     public function invalidArgumentProvider(): array

--- a/test/ExtensionLoadedTest.php
+++ b/test/ExtensionLoadedTest.php
@@ -8,7 +8,6 @@ use Laminas\Diagnostics\Result\FailureInterface;
 use Laminas\Diagnostics\Result\SuccessInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Traversable;
 
 use function phpversion;
 

--- a/test/ExtensionLoadedTest.php
+++ b/test/ExtensionLoadedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LaminasTest\Diagnostics;
+
+use InvalidArgumentException;
+use Laminas\Diagnostics\Check\ExtensionLoaded;
+use Laminas\Diagnostics\Result\FailureInterface;
+use Laminas\Diagnostics\Result\SuccessInterface;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Traversable;
+
+use function phpversion;
+
+/** @covers \Laminas\Diagnostics\Check\ExtensionLoaded */
+final class ExtensionLoadedTest extends TestCase
+{
+    /**
+     * @dataProvider invalidArgumentProvider
+     * @param string|array|Traversable $extensionName
+     */
+    public function testInvalidArguments($extensionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ExtensionLoaded($extensionName);
+    }
+
+    public function testCheck(): void
+    {
+        $check  = new ExtensionLoaded('json');
+        $result = $check->check();
+
+        self::assertInstanceof(SuccessInterface::class, $result);
+        self::assertSame('json ' . phpversion('json'), $result->getData());
+
+        $check  = new ExtensionLoaded('unknown-foo');
+        $result = $check->check();
+
+        self::assertInstanceof(FailureInterface::class, $result);
+        self::assertSame(['unknown-foo'], $result->getData());
+
+        $check  = new ExtensionLoaded(['unknown-foo', 'unknown-bar']);
+        $result = $check->check();
+
+        self::assertInstanceof(FailureInterface::class, $result);
+        self::assertSame(['unknown-foo', 'unknown-bar'], $result->getData());
+
+        $check  = new ExtensionLoaded(['json', 'xml']);
+        $result = $check->check();
+
+        self::assertInstanceof(SuccessInterface::class, $result);
+        self::assertSame(['json' => phpversion('json'), 'xml' => phpversion('xml')], $result->getData());
+    }
+
+    public function invalidArgumentProvider(): array
+    {
+        return [
+            [new stdClass()],
+            [100],
+        ];
+    }
+}

--- a/test/ExtensionLoadedTest.php
+++ b/test/ExtensionLoadedTest.php
@@ -17,7 +17,7 @@ final class ExtensionLoadedTest extends TestCase
 {
     /**
      * @dataProvider invalidArgumentProvider
-     * @param string|array|Traversable $extensionName
+     * @param mixed $extensionName
      */
     public function testInvalidArguments($extensionName): void
     {
@@ -34,6 +34,15 @@ final class ExtensionLoadedTest extends TestCase
         self::assertInstanceof(SuccessInterface::class, $result);
         self::assertSame('json ' . phpversion('json'), $result->getData());
 
+        $check  = new ExtensionLoaded(['json', 'xml']);
+        $result = $check->check();
+
+        self::assertInstanceof(SuccessInterface::class, $result);
+        self::assertSame(['json' => phpversion('json'), 'xml' => phpversion('xml')], $result->getData());
+    }
+
+    public function testCheckMissingExtension(): void
+    {
         $check  = new ExtensionLoaded('unknown-foo');
         $result = $check->check();
 
@@ -45,14 +54,11 @@ final class ExtensionLoadedTest extends TestCase
 
         self::assertInstanceof(FailureInterface::class, $result);
         self::assertSame(['unknown-foo', 'unknown-bar'], $result->getData());
-
-        $check  = new ExtensionLoaded(['json', 'xml']);
-        $result = $check->check();
-
-        self::assertInstanceof(SuccessInterface::class, $result);
-        self::assertSame(['json' => phpversion('json'), 'xml' => phpversion('xml')], $result->getData());
     }
 
+    /**
+     * @return array<int, array<int, mixed>>
+     */
     public function invalidArgumentProvider(): array
     {
         return [


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Adding extra Check Result `data` values for some checks where this was missing.
Created new ExtensionsLoadedTest, assumes that xml/json extensions exists (these are required by phpunit itself).
