### PR TITLE
Add responsetime/uptime/connection-count to memcache + redis checks

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -440,15 +440,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
-      <code>$memcache</code>
-      <code>$stats</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="3">
-      <code>addServer</code>
-      <code>connect</code>
-      <code>getExtendedStats</code>
-    </MixedMethodCall>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcache</code>
     </PropertyNotSetInConstructor>
@@ -460,15 +451,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
-      <code>$memcached</code>
-      <code>$stats</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="3">
-      <code>addServer</code>
-      <code>getLastDisconnectedServer</code>
-      <code>getStats</code>
-    </MixedMethodCall>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcached</code>
     </PropertyNotSetInConstructor>
@@ -1037,6 +1019,22 @@
       <code>$method</code>
       <code>$resultClass</code>
     </PossiblyNullArgument>
+  </file>
+  <file src="test/MemcacheTest.php">
+    <InvalidArgument occurrences="1">
+      <code>['127.0.0.1']</code>
+    </InvalidArgument>
+    <InvalidCast occurrences="1">
+      <code>['127.0.0.1']</code>
+    </InvalidCast>
+  </file>
+  <file src="test/MemcachedTest.php">
+    <InvalidArgument occurrences="1">
+      <code>['127.0.0.1']</code>
+    </InvalidArgument>
+    <InvalidCast occurrences="1">
+      <code>['127.0.0.1']</code>
+    </InvalidCast>
   </file>
   <file src="test/OpCacheMemoryTest.php">
     <InvalidScalarArgument occurrences="2">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -440,6 +440,15 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
+    <MixedAssignment occurrences="2">
+      <code>$memcache</code>
+      <code>$stats</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="3">
+      <code>addServer</code>
+      <code>connect</code>
+      <code>getExtendedStats</code>
+    </MixedMethodCall>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcache</code>
     </PropertyNotSetInConstructor>
@@ -451,6 +460,15 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
+    <MixedAssignment occurrences="2">
+      <code>$memcached</code>
+      <code>$stats</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="3">
+      <code>addServer</code>
+      <code>getLastDisconnectedServer</code>
+      <code>getStats</code>
+    </MixedMethodCall>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcached</code>
     </PropertyNotSetInConstructor>

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -13,6 +13,7 @@ use function class_exists;
 use function gettype;
 use function is_array;
 use function is_string;
+use function microtime;
 use function sprintf;
 
 /**
@@ -43,7 +44,7 @@ class Memcache extends AbstractCheck
         $port = (int) $port;
         if ($port < 1) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid port number - expecting a positive integer',
+                'Invalid port number %s - expecting a positive integer',
                 gettype($host)
             ));
         }
@@ -66,13 +67,17 @@ class Memcache extends AbstractCheck
         try {
             $memcache = new MemcacheService();
             $memcache->addServer($this->host, $this->port);
-            $stats = @$memcache->getExtendedStats();
 
-            $authority = sprintf('%s:%d', $this->host, $this->port);
+            $startTime = microtime(true);
+            /** @var false|array<string, false|array<string, int|string>> $stats */
+            $stats        = @$memcache->getExtendedStats();
+            $responseTime = microtime(true) - $startTime;
+
+            $authority   = sprintf('%s:%d', $this->host, $this->port);
+            $serviceData = null;
 
             if (
-                ! $stats
-                || ! is_array($stats)
+                ! is_array($stats)
                 || ! isset($stats[$authority])
                 || false === $stats[$authority]
             ) {
@@ -84,6 +89,12 @@ class Memcache extends AbstractCheck
                         $this->port
                     ));
                 }
+            } else {
+                $serviceData = [
+                    "responseTime" => $responseTime,
+                    "connections"  => (int) $stats[$authority]['curr_connections'],
+                    "uptime"       => (int) $stats[$authority]['uptime'],
+                ];
             }
         } catch (Exception $e) {
             return new Failure($e->getMessage());
@@ -93,6 +104,6 @@ class Memcache extends AbstractCheck
             'Memcache server running at host %s on port %s',
             $this->host,
             $this->port
-        ));
+        ), $serviceData);
     }
 }

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -44,8 +44,8 @@ class Memcache extends AbstractCheck
         $port = (int) $port;
         if ($port < 1) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid port number %s - expecting a positive integer',
-                gettype($host)
+                'Invalid port number %d - expecting a positive integer',
+                $port
             ));
         }
 

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -44,8 +44,8 @@ class Memcached extends AbstractCheck
         $port = (int) $port;
         if ($port < 1) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid port number %s - expecting a positive integer',
-                gettype($host)
+                'Invalid port number %d - expecting a positive integer',
+                $port
             ));
         }
 

--- a/test/MemcacheTest.php
+++ b/test/MemcacheTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LaminasTest\Diagnostics;
+
+use InvalidArgumentException;
+use Laminas\Diagnostics\Check\Memcache;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Laminas\Diagnostics\Check\Memcache */
+class MemcacheTest extends TestCase
+{
+    public function testHostValidation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot use array as host - expecting a string");
+        new Memcache(['127.0.0.1']);
+    }
+
+    public function testPortValidation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid port number -11211 - expecting a positive integer");
+        new Memcache('127.0.0.1', -11211);
+    }
+}

--- a/test/MemcachedTest.php
+++ b/test/MemcachedTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LaminasTest\Diagnostics;
+
+use InvalidArgumentException;
+use Laminas\Diagnostics\Check\Memcached;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Laminas\Diagnostics\Check\Memcached */
+class MemcachedTest extends TestCase
+{
+    public function testHostValidation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot use array as host - expecting a string");
+        new Memcached(['127.0.0.1']);
+    }
+
+    public function testPortValidation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid port number -11211 - expecting a positive integer");
+        new Memcached('127.0.0.1', -11211);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Bram Leeda <bram@123inkt.nl>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Added more CheckResult data values:
- responsetime
- uptime
- connections

Added as a keyed array following DirWritable, or do you prefer a dataclass for this for structured data?
There were no unittests for these classes unfortunately, to test this I'd need to be able to mock the Client instance.