### PR TITLE
Allow for Redis info arrays which use Clients and Server keys

### DIFF
--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -61,13 +61,20 @@ class Redis extends AbstractCheck
 
         if (array_key_exists('connected_clients', $stats)) {
             $successInformation['connections'] = (int) $stats['connected_clients'];
-        } elseif (array_key_exists('Clients', $stats) && is_array($stats['Clients']) && array_key_exists('connected_clients', $stats['Clients'])) {
+        } elseif (
+            array_key_exists('Clients', $stats) &&
+            is_array($stats['Clients']) &&
+            array_key_exists('connected_clients', $stats['Clients'])
+        ) {
             $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
         }
 
         if (array_key_exists('uptime_in_seconds', $stats)) {
             $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
-        } elseif (array_key_exists('Server', $stats) && is_array($stats['Server']) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
+        } elseif (
+            array_key_exists('Server', $stats) &&
+            is_array($stats['Server']) && array_key_exists('uptime_in_seconds', $stats['Server'])
+        ) {
             $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
         }
 

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function array_key_exists;
 use function class_exists;
+use function is_array;
 use function microtime;
 
 /**
@@ -60,15 +61,15 @@ class Redis extends AbstractCheck
 
         if (is_array($stats)) {
             if (array_key_exists('connected_clients', $stats)) {
-                $successInformation['connections'] = (int)$stats['connected_clients'];
+                $successInformation['connections'] = (int) $stats['connected_clients'];
             } elseif (array_key_exists('Clients', $stats) && array_key_exists('connected_clients', $stats['Clients'])) {
-                $successInformation['connections'] = (int)$stats['Clients']['connected_clients'];
+                $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
             }
 
             if (array_key_exists('uptime_in_seconds', $stats)) {
-                $successInformation['uptime'] = (int)$stats['uptime_in_seconds'];
+                $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
             } elseif (array_key_exists('Server', $stats) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
-                $successInformation['uptime'] = (int)$stats['Server']['uptime_in_seconds'];
+                $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
             }
         }
 

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -59,18 +59,16 @@ class Redis extends AbstractCheck
             "responseTime" => $responseTime,
         ];
 
-        if (is_array($stats)) {
-            if (array_key_exists('connected_clients', $stats)) {
-                $successInformation['connections'] = (int) $stats['connected_clients'];
-            } elseif (array_key_exists('Clients', $stats) && array_key_exists('connected_clients', $stats['Clients'])) {
-                $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
-            }
+        if (array_key_exists('connected_clients', $stats)) {
+            $successInformation['connections'] = (int) $stats['connected_clients'];
+        } elseif (array_key_exists('Clients', $stats) && is_array($stats['Clients']) && array_key_exists('connected_clients', $stats['Clients'])) {
+            $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
+        }
 
-            if (array_key_exists('uptime_in_seconds', $stats)) {
-                $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
-            } elseif (array_key_exists('Server', $stats) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
-                $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
-            }
+        if (array_key_exists('uptime_in_seconds', $stats)) {
+            $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
+        } elseif (array_key_exists('Server', $stats) && is_array($stats['Server']) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
+            $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
         }
 
         return new Success(

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -58,16 +58,18 @@ class Redis extends AbstractCheck
             "responseTime" => $responseTime,
         ];
 
-        if (array_key_exists('connected_clients', $stats)) {
-            $successInformation['connections'] = (int) $stats['connected_clients'];
-        } elseif (array_key_exists('Clients', $stats) && array_key_exists('connected_clients', $stats['Clients'])) {
-            $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
-        }
+        if (is_array($stats)) {
+            if (array_key_exists('connected_clients', $stats)) {
+                $successInformation['connections'] = (int)$stats['connected_clients'];
+            } elseif (array_key_exists('Clients', $stats) && array_key_exists('connected_clients', $stats['Clients'])) {
+                $successInformation['connections'] = (int)$stats['Clients']['connected_clients'];
+            }
 
-        if (array_key_exists('uptime_in_seconds', $stats)) {
-            $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
-        } elseif (array_key_exists('Server', $stats) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
-            $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
+            if (array_key_exists('uptime_in_seconds', $stats)) {
+                $successInformation['uptime'] = (int)$stats['uptime_in_seconds'];
+            } elseif (array_key_exists('Server', $stats) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
+                $successInformation['uptime'] = (int)$stats['Server']['uptime_in_seconds'];
+            }
         }
 
         return new Success(

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -8,6 +8,7 @@ use Redis as RedisExtensionClient;
 use RedisException;
 use RuntimeException;
 
+use function array_key_exists;
 use function class_exists;
 use function microtime;
 

--- a/src/Check/Redis.php
+++ b/src/Check/Redis.php
@@ -53,13 +53,25 @@ class Redis extends AbstractCheck
         $stats        = $client->info();
         $responseTime = microtime(true) - $startTime;
 
+        $successInformation = [
+            "responseTime" => $responseTime,
+        ];
+
+        if (array_key_exists('connected_clients', $stats)) {
+            $successInformation['connections'] = (int) $stats['connected_clients'];
+        } elseif (array_key_exists('Clients', $stats) && array_key_exists('connected_clients', $stats['Clients'])) {
+            $successInformation['connections'] = (int) $stats['Clients']['connected_clients'];
+        }
+
+        if (array_key_exists('uptime_in_seconds', $stats)) {
+            $successInformation['uptime'] = (int) $stats['uptime_in_seconds'];
+        } elseif (array_key_exists('Server', $stats) && array_key_exists('uptime_in_seconds', $stats['Server'])) {
+            $successInformation['uptime'] = (int) $stats['Server']['uptime_in_seconds'];
+        }
+
         return new Success(
             '',
-            [
-                "responseTime" => $responseTime,
-                "connections"  => (int) $stats["connected_clients"],
-                "uptime"       => (int) $stats["uptime_in_seconds"],
-            ]
+            $successInformation
         );
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The Redis Check has been extended by including response time, number of connected clients and uptime.   
(https://github.com/laminas/laminas-diagnostics/pull/57/files#diff-ae274e5d76cba73799bb44059a715045e3721dbe71f125ad128df5d2152c2a52)

However, the number of connected clients and uptime may need to be retrieved in slightly different ways, as the array structure returned by `Predis\ClientInterface::info()` can have different data structures. 

The previous behaviour only allowed directly retrieving `connected_clients` and `uptime_in_seconds` from the array returned by `Predis\ClientInterface::info()`. The suggested changes allow for those keys residing in `$array['Clients']` and `$array['Server']` respectively, as was the case in my setup. 

In my testing I used Redis V6.0.6 and Predis V1.1.10. 

NB: The suggested change allows for _both_ data structures of the info array. 