### PR TITLE
Add possibility to set zero port for memcache and memcached checkers

### DIFF
--- a/docs/book/diagnostics.md
+++ b/docs/book/diagnostics.md
@@ -336,6 +336,7 @@ use Laminas\Diagnostics\Check\Memcache;
 
 $checkLocal  = new Memcache('127.0.0.1'); // default port
 $checkBackup = new Memcache('10.0.30.40', 11212);
+$checkSocket = new Memcache('unix:///run/memcached/memcached.sock', 0);
 ```
 
 ## Memcached
@@ -348,6 +349,7 @@ use Laminas\Diagnostics\Check\Memcached;
 
 $checkLocal  = new Memcached('127.0.0.1'); // default port
 $checkBackup = new Memcached('10.0.30.40', 11212);
+$checkSocket = new Memcached('/run/memcached/memcached.sock', 0);
 ```
 
 ## MongoDb

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -437,18 +437,21 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Check/Memcache.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$port &lt; 0</code>
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$memcache</code>
-      <code>$stats</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="3">
       <code>addServer</code>
       <code>connect</code>
       <code>getExtendedStats</code>
     </MixedMethodCall>
+    <NoValue occurrences="1">
+      <code>$port</code>
+    </NoValue>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcache</code>
     </PropertyNotSetInConstructor>
@@ -457,18 +460,21 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Check/Memcached.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$port &lt; 0</code>
       <code>is_string($host)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$memcached</code>
-      <code>$stats</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="3">
       <code>addServer</code>
       <code>getLastDisconnectedServer</code>
       <code>getStats</code>
     </MixedMethodCall>
+    <NoValue occurrences="1">
+      <code>$port</code>
+    </NoValue>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Memcached</code>
     </PropertyNotSetInConstructor>
@@ -602,9 +608,33 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/Check/Redis.php">
+    <MixedAssignment occurrences="1">
+      <code>$client</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>PredisClient|RedisExtensionClient</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>auth</code>
+      <code>connect</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$client</code>
+    </MixedReturnStatement>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Redis</code>
     </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>RedisException</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="3">
+      <code>$client</code>
+      <code>PredisClient|RedisExtensionClient</code>
+      <code>RedisException</code>
+    </UndefinedDocblockClass>
+    <UnnecessaryVarAnnotation occurrences="1">
+      <code>array</code>
+    </UnnecessaryVarAnnotation>
   </file>
   <file src="src/Check/SecurityAdvisory.php">
     <DocblockTypeContradiction occurrences="1">
@@ -1039,7 +1069,8 @@
     </PossiblyNullArgument>
   </file>
   <file src="test/MemcacheTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="2">
+      <code>-11211</code>
       <code>['127.0.0.1']</code>
     </InvalidArgument>
     <InvalidCast occurrences="1">
@@ -1047,7 +1078,8 @@
     </InvalidCast>
   </file>
   <file src="test/MemcachedTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="2">
+      <code>-11211</code>
       <code>['127.0.0.1']</code>
     </InvalidArgument>
     <InvalidCast occurrences="1">

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -28,8 +28,11 @@ class Memcache extends AbstractCheck
     protected $port;
 
     /**
-     * @param string $host
-     * @param int    $port
+     * @param string $host The hostname of the memcache server. This parameter may
+     *                     also specify other transports like unix:///run/memcached/memcached.sock
+     *                     to use UNIX domain sockets, in this case port must also be set to 0.
+     * @param int    $port The port where memcached is listening for connections.
+     *                     Set this parameter to 0 when using UNIX domain sockets.
      * @throws InvalidArgumentException
      */
     public function __construct($host = '127.0.0.1', $port = 11211)

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -28,11 +28,11 @@ class Memcache extends AbstractCheck
     protected $port;
 
     /**
-     * @param string $host The hostname of the memcache server. This parameter may
-     *                     also specify other transports like unix:///run/memcached/memcached.sock
-     *                     to use UNIX domain sockets, in this case port must also be set to 0.
-     * @param int    $port The port where memcached is listening for connections.
-     *                     Set this parameter to 0 when using UNIX domain sockets.
+     * @param string         $host The hostname of the memcache server. This parameter may
+     *                             also specify other transports like unix:///run/memcached/memcached.sock
+     *                             to use UNIX domain sockets, in this case port must also be set to 0.
+     * @param 0|positive-int $port The port where memcached is listening for connections.
+     *                             Set this parameter to 0 when using UNIX domain sockets.
      * @throws InvalidArgumentException
      */
     public function __construct($host = '127.0.0.1', $port = 11211)

--- a/src/Check/Memcache.php
+++ b/src/Check/Memcache.php
@@ -42,9 +42,9 @@ class Memcache extends AbstractCheck
         }
 
         $port = (int) $port;
-        if ($port < 1) {
+        if ($port < 0) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid port number %d - expecting a positive integer',
+                'Invalid port number %d - expecting an unsigned integer',
                 $port
             ));
         }

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -42,9 +42,9 @@ class Memcached extends AbstractCheck
         }
 
         $port = (int) $port;
-        if ($port < 1) {
+        if ($port < 0) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid port number %d - expecting a positive integer',
+                'Invalid port number %d - expecting an unsigned integer',
                 $port
             ));
         }

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -30,7 +30,7 @@ class Memcached extends AbstractCheck
      * @param string $host
      * @param int    $port
      * @throws InvalidArgumentException If host is not a string value.
-     * @throws InvalidArgumentException If port is less than 1.
+     * @throws InvalidArgumentException If port is less than 0.
      */
     public function __construct($host = '127.0.0.1', $port = 11211)
     {

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -27,8 +27,11 @@ class Memcached extends AbstractCheck
     protected $port;
 
     /**
-     * @param string $host
-     * @param int    $port
+     * @param string $host The hostname of the memcache server. This parameter may
+     *                     also specify other transports like /path/to/memcached.sock
+     *                     to use UNIX domain sockets, in this case port must also be set to 0.
+     * @param int    $port The port where memcached is listening for connections.
+     *                     Set this parameter to 0 when using UNIX domain sockets.
      * @throws InvalidArgumentException If host is not a string value.
      * @throws InvalidArgumentException If port is less than 0.
      */

--- a/src/Check/Memcached.php
+++ b/src/Check/Memcached.php
@@ -27,11 +27,11 @@ class Memcached extends AbstractCheck
     protected $port;
 
     /**
-     * @param string $host The hostname of the memcache server. This parameter may
-     *                     also specify other transports like /path/to/memcached.sock
-     *                     to use UNIX domain sockets, in this case port must also be set to 0.
-     * @param int    $port The port where memcached is listening for connections.
-     *                     Set this parameter to 0 when using UNIX domain sockets.
+     * @param string         $host The hostname of the memcache server. This parameter may
+     *                             also specify other transports like /path/to/memcached.sock
+     *                             to use UNIX domain sockets, in this case port must also be set to 0.
+     * @param 0|positive-int $port The port where memcached is listening for connections.
+     *                             Set this parameter to 0 when using UNIX domain sockets.
      * @throws InvalidArgumentException If host is not a string value.
      * @throws InvalidArgumentException If port is less than 0.
      */

--- a/test/MemcacheTest.php
+++ b/test/MemcacheTest.php
@@ -19,7 +19,7 @@ class MemcacheTest extends TestCase
     public function testPortValidation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid port number -11211 - expecting a positive integer");
+        $this->expectExceptionMessage("Invalid port number -11211 - expecting an unsigned integer");
         new Memcache('127.0.0.1', -11211);
     }
 }

--- a/test/MemcacheTest.php
+++ b/test/MemcacheTest.php
@@ -2,7 +2,6 @@
 
 namespace LaminasTest\Diagnostics;
 
-use Generator;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Check\Memcache;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +25,7 @@ class MemcacheTest extends TestCase
 
     /**
      * @dataProvider providerValidConstructorArguments
+     * @param array<empty, empty>|array{string}|array{string, positive-int|0} $arguments
      */
     public function testConstructor(array $arguments): void
     {
@@ -34,24 +34,30 @@ class MemcacheTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function providerValidConstructorArguments(): Generator
+    /**
+     * @return non-empty-array<
+     *     non-empty-string,
+     *     array{array<empty, empty>|array{string}|array{string, positive-int|0}}
+     * >
+     */
+    public static function providerValidConstructorArguments(): array
     {
-        yield 'no arguments' => [
-            [],
-        ];
-        yield 'only host' => [
-            ['127.0.0.1'],
-        ];
-        yield 'host and port' => [
-            [
-                '127.0.0.1',
-                11211,
+        return [
+            'no arguments'  => [[]],
+            'only host'     => [
+                ['127.0.0.1'],
             ],
-        ];
-        yield 'unix socket' => [
-            [
-                'unix:///run/memcached/memcached.sock',
-                0,
+            'host and port' => [
+                [
+                    '127.0.0.1',
+                    11211,
+                ],
+            ],
+            'unix socket'   => [
+                [
+                    'unix:///run/memcached/memcached.sock',
+                    0,
+                ],
             ],
         ];
     }

--- a/test/MemcacheTest.php
+++ b/test/MemcacheTest.php
@@ -2,6 +2,7 @@
 
 namespace LaminasTest\Diagnostics;
 
+use Generator;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Check\Memcache;
 use PHPUnit\Framework\TestCase;
@@ -21,5 +22,37 @@ class MemcacheTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid port number -11211 - expecting an unsigned integer");
         new Memcache('127.0.0.1', -11211);
+    }
+
+    /**
+     * @dataProvider providerValidConstructorArguments
+     */
+    public function testConstructor(array $arguments): void
+    {
+        new Memcache(...$arguments);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function providerValidConstructorArguments(): Generator
+    {
+        yield 'no arguments' => [
+            [],
+        ];
+        yield 'only host' => [
+            ['127.0.0.1'],
+        ];
+        yield 'host and port' => [
+            [
+                '127.0.0.1',
+                11211,
+            ],
+        ];
+        yield 'unix socket' => [
+            [
+                'unix:///run/memcached/memcached.sock',
+                0,
+            ],
+        ];
     }
 }

--- a/test/MemcachedTest.php
+++ b/test/MemcachedTest.php
@@ -2,6 +2,7 @@
 
 namespace LaminasTest\Diagnostics;
 
+use Generator;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Check\Memcached;
 use PHPUnit\Framework\TestCase;
@@ -21,5 +22,37 @@ class MemcachedTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid port number -11211 - expecting an unsigned integer");
         new Memcached('127.0.0.1', -11211);
+    }
+
+    /**
+     * @dataProvider providerValidConstructorArguments
+     */
+    public function testConstructor(array $arguments): void
+    {
+        new Memcached(...$arguments);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function providerValidConstructorArguments(): Generator
+    {
+        yield 'no arguments' => [
+            [],
+        ];
+        yield 'only host' => [
+            ['127.0.0.1'],
+        ];
+        yield 'host and port' => [
+            [
+                '127.0.0.1',
+                11211,
+            ],
+        ];
+        yield 'unix socket' => [
+            [
+                '/run/memcached/memcached.sock',
+                0,
+            ],
+        ];
     }
 }

--- a/test/MemcachedTest.php
+++ b/test/MemcachedTest.php
@@ -2,7 +2,6 @@
 
 namespace LaminasTest\Diagnostics;
 
-use Generator;
 use InvalidArgumentException;
 use Laminas\Diagnostics\Check\Memcached;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +25,7 @@ class MemcachedTest extends TestCase
 
     /**
      * @dataProvider providerValidConstructorArguments
+     * @param array<empty, empty>|array{string}|array{string, positive-int|0} $arguments
      */
     public function testConstructor(array $arguments): void
     {
@@ -34,24 +34,30 @@ class MemcachedTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function providerValidConstructorArguments(): Generator
+    /**
+     * @return non-empty-array<
+     *     non-empty-string,
+     *     array{array<empty, empty>|array{string}|array{string, positive-int|0}}
+     * >
+     */
+    public static function providerValidConstructorArguments(): array
     {
-        yield 'no arguments' => [
-            [],
-        ];
-        yield 'only host' => [
-            ['127.0.0.1'],
-        ];
-        yield 'host and port' => [
-            [
-                '127.0.0.1',
-                11211,
+        return [
+            'no arguments'  => [[]],
+            'only host'     => [
+                ['127.0.0.1'],
             ],
-        ];
-        yield 'unix socket' => [
-            [
-                '/run/memcached/memcached.sock',
-                0,
+            'host and port' => [
+                [
+                    '127.0.0.1',
+                    11211,
+                ],
+            ],
+            'unix socket'   => [
+                [
+                    'unix:///run/memcached/memcached.sock',
+                    0,
+                ],
             ],
         ];
     }

--- a/test/MemcachedTest.php
+++ b/test/MemcachedTest.php
@@ -19,7 +19,7 @@ class MemcachedTest extends TestCase
     public function testPortValidation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid port number -11211 - expecting a positive integer");
+        $this->expectExceptionMessage("Invalid port number -11211 - expecting an unsigned integer");
         new Memcached('127.0.0.1', -11211);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
It is impossible to pass zero to a port argument for Memcache and Memcached checkers when using UNIX domain sockets. But the documentation ([memcache.addServer](https://www.php.net/manual/en/memcache.addserver.php), [memcached.addServer](https://www.php.net/manual/en/memcached.addserver.php)) says "As of version 2.0.0b1, set this parameter to 0 when using UNIX domain sockets."

