### PR TITLE
Add ResultInterface template

### DIFF
--- a/src/Check/DiskFree.php
+++ b/src/Check/DiskFree.php
@@ -31,6 +31,8 @@ use function substr;
  *     authors:   Dave Ingram <dave@dmi.me.uk>, Nick Pope <nick@nickpope.me.uk>
  *     license:   http://creativecommons.org/licenses/BSD/ CC-BSD
  *     copyright: Copyright (c) 2010, Dave Ingram, Nick Pope
+ *
+ * @psalm-type ResultData array{availability: array{value: float, valueType: string}}
  */
 class DiskFree extends AbstractCheck implements CheckInterface
 {
@@ -168,7 +170,7 @@ class DiskFree extends AbstractCheck implements CheckInterface
      *
      * @see \Laminas\Diagnostics\Check\CheckInterface::check()
      *
-     * @return Failure|Success|Warning
+     * @return Failure<ResultData>|Success<ResultData>|Warning
      */
     public function check()
     {
@@ -186,10 +188,10 @@ class DiskFree extends AbstractCheck implements CheckInterface
         $description       = sprintf('Remaining space at %s: %s', $this->path, $freeHumanReadable);
 
         if (disk_free_space($this->path) < $this->minDiskBytes) {
-            return new Failure($description, $free);
+            return new Failure($description, ['availability' => ['value' => $free, 'valueType' => 'bytes']]);
         }
 
-        return new Success($description, $free);
+        return new Success($description, ['availability' => ['value' => $free, 'valueType' => 'bytes']]);
     }
 
     /**

--- a/src/Check/DiskUsage.php
+++ b/src/Check/DiskUsage.php
@@ -15,6 +15,8 @@ use function sprintf;
 
 /**
  * Checks to see if the disk usage is below warning/critical percent thresholds
+ *
+ * @psalm-type ResultData array{utilization: array{value: float, valueType: string}}
  */
 class DiskUsage extends AbstractCheck implements CheckInterface
 {
@@ -85,7 +87,7 @@ class DiskUsage extends AbstractCheck implements CheckInterface
     /**
      * Perform the check
      *
-     * @return Failure|Success|Warning
+     * @return Failure<ResultData>|Success<ResultData>|Warning<ResultData>
      */
     public function check()
     {
@@ -95,13 +97,22 @@ class DiskUsage extends AbstractCheck implements CheckInterface
         $dp = ($du / $dt) * 100;
 
         if ($dp >= $this->criticalThreshold) {
-            return new Failure(sprintf('Disk usage too high: %2d percent.', $dp), $dp);
+            return new Failure(
+                sprintf('Disk usage too high: %2d percent.', $dp),
+                ['utilization' => ['value' => $dp, 'valueType' => 'percentage']]
+            );
         }
 
         if ($dp >= $this->warningThreshold) {
-            return new Warning(sprintf('Disk usage high: %2d percent.', $dp), $dp);
+            return new Warning(
+                sprintf('Disk usage high: %2d percent.', $dp),
+                ['utilization' => ['value' => $dp, 'valueType' => 'percentage']]
+            );
         }
 
-        return new Success(sprintf('Disk usage is %2d percent.', $dp), $dp);
+        return new Success(
+            sprintf('Disk usage is %2d percent.', $dp),
+            ['utilization' => ['value' => $dp, 'valueType' => 'percentage']]
+        );
     }
 }

--- a/src/Result/AbstractResult.php
+++ b/src/Result/AbstractResult.php
@@ -4,20 +4,22 @@ namespace Laminas\Diagnostics\Result;
 
 /**
  * Abstract, simple implementation of ResultInterface
+ *
+ * @template T
  */
 abstract class AbstractResult implements ResultInterface
 {
     /** @var string */
     protected $message;
 
-    /** @var mixed|null */
+    /** @var T|null */
     protected $data;
 
     /**
      * Create new result
      *
-     * @param string      $message
-     * @param mixed|null  $data
+     * @param string $message
+     * @param T|null $data
      */
     public function __construct($message = '', $data = null)
     {
@@ -41,7 +43,7 @@ abstract class AbstractResult implements ResultInterface
     /**
      * Get detailed info on the test result (if available).
      *
-     * @return mixed|null
+     * @return T|null
      */
     public function getData()
     {
@@ -49,7 +51,7 @@ abstract class AbstractResult implements ResultInterface
     }
 
     /**
-     * @param mixed|null $data
+     * @param T|null $data
      */
     public function setData($data)
     {

--- a/src/Result/Failure.php
+++ b/src/Result/Failure.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @extends AbstractResult<T>
+ * @implements FailureInterface<T>
+ */
 class Failure extends AbstractResult implements FailureInterface
 {
 }

--- a/src/Result/FailureInterface.php
+++ b/src/Result/FailureInterface.php
@@ -2,6 +2,10 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @implements ResultInterface<T>
+ */
 interface FailureInterface extends ResultInterface
 {
 }

--- a/src/Result/ResultInterface.php
+++ b/src/Result/ResultInterface.php
@@ -2,6 +2,9 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ */
 interface ResultInterface
 {
     /**
@@ -14,7 +17,7 @@ interface ResultInterface
     /**
      * Get detailed info on the test result (if available).
      *
-     * @return mixed|null
+     * @return T|null
      */
     public function getData();
 }

--- a/src/Result/Skip.php
+++ b/src/Result/Skip.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @extends AbstractResult<T>
+ * @implements SkipInterface<T>
+ */
 class Skip extends AbstractResult implements SkipInterface
 {
 }

--- a/src/Result/SkipInterface.php
+++ b/src/Result/SkipInterface.php
@@ -2,6 +2,10 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @implements ResultInterface<T>
+ */
 interface SkipInterface extends ResultInterface
 {
 }

--- a/src/Result/Success.php
+++ b/src/Result/Success.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @extends AbstractResult<T>
+ * @implements SuccessInterface<T>
+ */
 class Success extends AbstractResult implements SuccessInterface
 {
 }

--- a/src/Result/SuccessInterface.php
+++ b/src/Result/SuccessInterface.php
@@ -2,6 +2,10 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @implements ResultInterface<T>
+ */
 interface SuccessInterface extends ResultInterface
 {
 }

--- a/src/Result/Warning.php
+++ b/src/Result/Warning.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @extends AbstractResult<T>
+ * @implements WarningInterface<T>
+ */
 class Warning extends AbstractResult implements WarningInterface
 {
 }

--- a/src/Result/WarningInterface.php
+++ b/src/Result/WarningInterface.php
@@ -2,6 +2,10 @@
 
 namespace Laminas\Diagnostics\Result;
 
+/**
+ * @template T
+ * @implements ResultInterface<T>
+ */
 interface WarningInterface extends ResultInterface
 {
 }

--- a/test/BasicClassesTest.php
+++ b/test/BasicClassesTest.php
@@ -86,6 +86,7 @@ final class BasicClassesTest extends TestCase
 
     public function testSetters(): void
     {
+        /** @var Success<mixed> $result */
         $result = new Success();
 
         self::assertSame('', $result->getMessage());

--- a/test/DiskUsageTest.php
+++ b/test/DiskUsageTest.php
@@ -41,19 +41,28 @@ final class DiskUsageTest extends TestCase
         $result = $check->check();
 
         self::assertInstanceof(SuccessInterface::class, $result);
-        self::assertSame($dp, $result->getData());
+        $data = $result->getData();
+        self::assertNotNull($data);
+        self::assertSame($dp, $data['utilization']['value']);
+        self::assertSame('percentage', $data['utilization']['valueType']);
 
         $check  = new DiskUsage($dp - 1, 100, $this->getTempDir());
         $result = $check->check();
 
         self::assertInstanceof(WarningInterface::class, $result);
-        self::assertSame($dp, $result->getData());
+        $data = $result->getData();
+        self::assertNotNull($data);
+        self::assertSame($dp, $data['utilization']['value']);
+        self::assertSame('percentage', $data['utilization']['valueType']);
 
         $check  = new DiskUsage(0, $dp - 1, $this->getTempDir());
         $result = $check->check();
 
         self::assertInstanceof(FailureInterface::class, $result);
-        self::assertSame($dp, $result->getData());
+        $data = $result->getData();
+        self::assertNotNull($data);
+        self::assertSame($dp, $data['utilization']['value']);
+        self::assertSame('percentage', $data['utilization']['valueType']);
     }
 
     public function invalidArgumentProvider(): array


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | maybe
| New Feature   | no
| RFC           | [yes](https://github.com/laminas/laminas-diagnostics/issues/59)
| QA            | no

Add ResultInterface template for the `data` field, for strict typing in the Check classes.

Started with DiskFree and DiskUsage checks.
- Changed the `data` value/structure so it's visible what kind of data is returned as well

If acceptable I will continue with the other checks.

Signed-off-by: Bram Leeda <bram@123inkt.nl>