### PR TITLE
fix(process-check): support Alpine Linux ps command

### DIFF
--- a/src/Check/ProcessRunning.php
+++ b/src/Check/ProcessRunning.php
@@ -7,12 +7,12 @@ use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\ResultInterface;
 use Laminas\Diagnostics\Result\Success;
 
-use function escapeshellarg;
 use function exec;
 use function gettype;
 use function is_numeric;
 use function is_scalar;
 use function sprintf;
+use function str_contains;
 
 /**
  * Check if a process with given name or ID is currently running.
@@ -94,12 +94,18 @@ class ProcessRunning extends AbstractCheck
      */
     private function checkAgainstProcessName()
     {
-        exec('ps -efww | grep ' . escapeshellarg($this->processName) . ' | grep -v grep', $output, $return);
+        exec('ps -eo pid,args', $output, $return);
 
         if ($return > 0) {
             return new Failure(sprintf('Could not find any running process containing "%s"', $this->processName));
         }
 
-        return new Success();
+        foreach ($output as $line) {
+            if (str_contains($line, $this->processName)) {
+                return new Success();
+            }
+        }
+
+        return new Failure(sprintf('Could not find any running process containing "%s"', $this->processName));
     }
 }

--- a/src/Check/ProcessRunning.php
+++ b/src/Check/ProcessRunning.php
@@ -100,6 +100,7 @@ class ProcessRunning extends AbstractCheck
             return new Failure(sprintf('Could not find any running process containing "%s"', $this->processName));
         }
 
+        /** @var string $line */
         foreach ($output as $line) {
             if (str_contains($line, $this->processName)) {
                 return new Success();

--- a/src/Check/ProcessRunning.php
+++ b/src/Check/ProcessRunning.php
@@ -94,6 +94,10 @@ class ProcessRunning extends AbstractCheck
      */
     private function checkAgainstProcessName()
     {
+        /**
+         * @see https://man7.org/linux/man-pages/ps.1.html (search for 'ps -eo') for GNU implementation
+         * @see https://busybox.net/downloads/BusyBox.html (search for 'ps') for BusyBox implementation
+         */
         exec('ps -eo pid,args', $output, $return);
 
         if ($return > 0) {


### PR DESCRIPTION



|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Replaced unsupported `ps -efww` with `ps -eo pid,args` for BusyBox compatibility. Moved filtering logic to PHP/grep to ensure reliable process detection on Alpine-based containers.